### PR TITLE
[bachend] DEV-135: Add EditorConfig and StyleCop, update .gitignore

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,65 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.cs]
+#### ПРАВИЛА ІМЕНУВАННЯ (Naming Conventions) ####
+
+# Символи мають бути PascalCase (Класи, Методи, Властивості)
+dotnet_naming_rule.pascal_case_rule.severity = error
+dotnet_naming_rule.pascal_case_rule.symbols = method_and_property_symbols
+dotnet_naming_rule.pascal_case_rule.style = pascal_case_style
+
+dotnet_naming_symbols.method_and_property_symbols.applicable_kinds = method, property, class, struct, enum
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Приватні поля: _camelCase
+dotnet_naming_rule.private_fields_with_underscore.severity = error
+dotnet_naming_rule.private_fields_with_underscore.symbols = private_fields_symbols
+dotnet_naming_rule.private_fields_with_underscore.style = prefix_underscore_style
+
+dotnet_naming_symbols.private_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_fields_symbols.applicable_accessibilities = private
+dotnet_naming_style.prefix_underscore_style.capitalization = camel_case
+dotnet_naming_style.prefix_underscore_style.required_prefix = _
+
+# Allow StyleCop SA1309 (leading underscore) to be disabled so dotnet_naming rules
+# can enforce a private field naming style with a leading underscore.
+dotnet_diagnostic.SA1309.severity = none
+# Інтерфейси: IPascalCase
+dotnet_naming_rule.interface_prefix_i.severity = error
+dotnet_naming_rule.interface_prefix_i.symbols = interface_symbols
+dotnet_naming_rule.interface_prefix_i.style = i_prefix_style
+
+dotnet_naming_symbols.interface_symbols.applicable_kinds = interface
+dotnet_naming_style.i_prefix_style.capitalization = pascal_case
+dotnet_naming_style.i_prefix_style.required_prefix = I
+
+# Локальні змінні та параметри: camelCase
+dotnet_naming_rule.camel_case_rule.severity = suggestion
+dotnet_naming_rule.camel_case_rule.symbols = local_and_parameter_symbols
+dotnet_naming_rule.camel_case_rule.style = camel_case_style
+
+dotnet_naming_symbols.local_and_parameter_symbols.applicable_kinds = parameter, local
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+#### ПРАВИЛА ФОРМАТУВАННЯ (Formatting) ####
+
+# Фігурні дужки з нового рядка (Allman style)
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+
+# Відступи та довжина рядка
+indent_size = 4
+tab_width = 4
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,22 @@ project.lock.json
 project.fragment.lock.json
 artifacts/
 
+# .NET Artifacts
+appsettings.Development.json
+
+# User-specific files
+*.user
+*.userosscache
+*.sln.doccache
+
+# Секрети та оточення
+.env
+.env.local
+
+# IDE
+.vscode/
+.idea/
+
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt
 

--- a/server/stylecop.json
+++ b/server/stylecop.json
@@ -1,0 +1,31 @@
+{
+    "settings": {
+        "namingRules": {
+            "allowLeadingUnderscore": true,
+            "fieldNames": {
+                "private": {
+                    "requiredPrefix": "_",
+                    "capitalization": "camel_case"
+                }
+            }
+        },
+        "maintainabilityRules": {
+            "topLevelTypes": [
+                "class",
+                "interface",
+                "struct",
+                "enum"
+            ]
+        },
+        "layoutRules": {
+            "newlineAtEndOfFile": "require"
+        },
+        "documentationRules": {
+            "companyName": "TournamentPlatform",
+            "documentInterfaces": true,
+            "documentExposedElements": true,
+            "documentInternalElements": false,
+            "documentPrivateElements": false
+        }
+    }
+}


### PR DESCRIPTION
Introduce .editorconfig with C# naming and formatting rules (PascalCase for types/members, _camelCase for private fields, I-prefix for interfaces, camelCase locals, Allman brace style, max line length). Add server/stylecop.json to align StyleCop settings (allow leading underscore, private field prefix, documentation and layout rules). Update .gitignore to ignore environment and IDE/user files (appsettings.Development.json, .env*, .vscode/, .idea/, *.user, etc.) to avoid leaking secrets and reduce noise.