### PR TITLE
[backend] DEV-154: Add example JSON payloads for tournaments API

### DIFF
--- a/server/examples/create-tournament-request.json
+++ b/server/examples/create-tournament-request.json
@@ -1,0 +1,9 @@
+{
+  "title": "Kyiv Spring Open 2026",
+  "startDate": "2026-05-10T10:00:00Z",
+  "endDate": "2026-05-11T10:00:00Z",
+  "registrationDeadline": "2026-05-08T18:00:00Z",
+  "maxParticipants": 16,
+  "description": "Щорічний турнір з настільного тенісу.",
+  "themeId": "550e8400-e29b-41d4-a716-446655440000"
+}

--- a/server/examples/error-response-example.json
+++ b/server/examples/error-response-example.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2026-04-08T21:15:03Z",
+  "errorCode": "REGISTRATION_LIMIT_REACHED",
+  "message": "Неможливо приєднатися: ліміт учасників для цього турніру (16) вичерпано.",
+  "path": "/api/v1/tournaments/f47ac10b/participants",
+  "traceId": "req-99-xfgh-001",
+  "details": {
+    "currentCount": 16,
+    "limit": 16
+  }
+}

--- a/server/examples/register-participant-request.json
+++ b/server/examples/register-participant-request.json
@@ -1,0 +1,3 @@
+{
+  "playerId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+}


### PR DESCRIPTION
Add three example JSON files under server/examples: create-tournament-request.json (sample Kyiv Spring Open 2026 tournament with ISO timestamps, Ukrainian description, maxParticipants and themeId UUID), register-participant-request.json (sample playerId UUID), and error-response-example.json (registration limit reached error payload including currentCount and limit). These examples are intended to aid API documentation and testing.