### PR TITLE
Fix schema structural issues in init_db.sql

### DIFF
--- a/db/init_db.sql
+++ b/db/init_db.sql
@@ -1,11 +1,5 @@
 -- ============================================================================
--- 1. CREATE EXTENSIONS FOR UUID SUPPORT
--- ============================================================================
-
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
--- ============================================================================
--- 2. CREATE ENUM TYPES
+-- 1. CREATE ENUM TYPES
 -- ============================================================================
 
 CREATE TYPE tournament_status AS ENUM (
@@ -16,11 +10,11 @@ CREATE TYPE tournament_status AS ENUM (
 );
 
 -- ============================================================================
--- 3. CREATE ACCOUNT_STATE TABLE (Lookup)
+-- 2. CREATE ACCOUNT_STATE TABLE (Lookup)
 -- ============================================================================
 
 CREATE TABLE account_state (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(50) NOT NULL UNIQUE,
     description VARCHAR(255),
     is_active BOOLEAN DEFAULT true,
@@ -35,11 +29,11 @@ INSERT INTO account_state (name, description) VALUES
     ('banned', 'User account is banned');
 
 -- ============================================================================
--- 4. CREATE USER TABLE (with soft delete & audit trail)
+-- 3. CREATE USER TABLE (with soft delete & audit trail)
 -- ============================================================================
 
 CREATE TABLE "user" (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     full_name VARCHAR(255) NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     is_organizer BOOLEAN DEFAULT false,
@@ -54,11 +48,11 @@ CREATE INDEX idx_user_is_organizer ON "user"(is_organizer);
 CREATE INDEX idx_user_deleted_at ON "user"(deleted_at);
 
 -- ============================================================================
--- 5. CREATE USER_DETAILS TABLE (Optional, cascade hard-delete with user)
+-- 4. CREATE USER_DETAILS TABLE (Optional, cascade hard-delete with user)
 -- ============================================================================
 
 CREATE TABLE user_details (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL UNIQUE REFERENCES "user"(id) ON DELETE CASCADE,
     email VARCHAR(255) UNIQUE NOT NULL,
     date_of_birth DATE NOT NULL,
@@ -70,11 +64,11 @@ CREATE INDEX idx_user_details_user_id ON user_details(user_id);
 CREATE INDEX idx_user_details_email ON user_details(email);
 
 -- ============================================================================
--- 6. CREATE USER_PHONE TABLE (Multiple phones per user, cascade hard-delete)
+-- 5. CREATE USER_PHONE TABLE (Multiple phones per user, cascade hard-delete)
 -- ============================================================================
 
 CREATE TABLE user_phone (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
     phone_number VARCHAR(20) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -85,11 +79,11 @@ CREATE INDEX idx_user_phone_user_id ON user_phone(user_id);
 CREATE INDEX idx_user_phone_phone_number ON user_phone(phone_number);
 
 -- ============================================================================
--- 7. CREATE TOURNAMENT_THEME TABLE (Lookup)
+-- 6. CREATE TOURNAMENT_THEME TABLE (Lookup)
 -- ============================================================================
 
 CREATE TABLE tournament_theme (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(100) NOT NULL UNIQUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -103,11 +97,11 @@ INSERT INTO tournament_theme (name) VALUES
     ('Rocket League');
 
 -- ============================================================================
--- 8. CREATE TOURNAMENT TABLE (with background_img, soft delete & audit trail)
+-- 7. CREATE TOURNAMENT TABLE (with background_img, soft delete & audit trail)
 -- ============================================================================
 
 CREATE TABLE tournament (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
     organizer_id UUID REFERENCES "user"(id) ON DELETE SET NULL,
     theme_id UUID NOT NULL REFERENCES tournament_theme(id),
@@ -133,11 +127,11 @@ CREATE INDEX idx_tournament_start_date ON tournament(start_date);
 CREATE INDEX idx_tournament_registration_deadline ON tournament(registration_deadline);
 
 -- ============================================================================
--- 9. CREATE TEAM TABLE (Tournament-scoped, deletable)
+-- 8. CREATE TEAM TABLE (Tournament-scoped, deletable)
 -- ============================================================================
 
 CREATE TABLE team (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
     tournament_id UUID NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
     is_disqualified BOOLEAN DEFAULT false,
@@ -150,11 +144,11 @@ CREATE INDEX idx_team_tournament_id ON team(tournament_id);
 CREATE INDEX idx_team_is_disqualified ON team(is_disqualified);
 
 -- ============================================================================
--- 10. CREATE USER_TEAM TABLE (Junction, immutable membership)
+-- 9. CREATE USER_TEAM TABLE (Junction, immutable membership)
 -- ============================================================================
 
 CREATE TABLE user_team (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE RESTRICT,
     team_id UUID NOT NULL REFERENCES team(id) ON DELETE RESTRICT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -165,11 +159,11 @@ CREATE INDEX idx_user_team_user_id ON user_team(user_id);
 CREATE INDEX idx_user_team_team_id ON user_team(team_id);
 
 -- ============================================================================
--- 11. CREATE MATCH TABLE (Immutable, single elimination)
+-- 10. CREATE MATCH TABLE (Immutable, single elimination)
 -- ============================================================================
 
 CREATE TABLE match (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     tournament_id UUID NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
     team_a_id UUID NOT NULL REFERENCES team(id) ON DELETE RESTRICT,
     team_b_id UUID REFERENCES team(id) ON DELETE SET NULL,
@@ -184,7 +178,7 @@ CREATE TABLE match (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_match_position UNIQUE (tournament_id, level, order_number),
     CONSTRAINT valid_different_teams CHECK (team_a_id != team_b_id),
-    CONSTRAINT valid_winner CHECK (winner_id IS NULL OR winner_id IN (team_a_id, team_b_id)),
+    CONSTRAINT valid_winner CHECK (winner_id IS NULL OR winner_id = team_a_id OR (team_b_id IS NOT NULL AND winner_id = team_b_id)),
     CONSTRAINT valid_scores CHECK (team_a_score >= 0 AND team_b_score >= 0)
 );
 
@@ -196,7 +190,7 @@ CREATE INDEX idx_match_is_valid ON match(is_valid);
 CREATE INDEX idx_match_level ON match(level);
 
 -- ============================================================================
--- 12. CREATE TRIGGERS (Immutability enforcement, audit & GDPR compliance)
+-- 11. CREATE TRIGGERS (Immutability enforcement, audit & GDPR compliance)
 -- ============================================================================
 
 -- Prevent match deletion
@@ -278,8 +272,8 @@ FOR EACH ROW
 WHEN (OLD.deleted_at IS DISTINCT FROM NEW.deleted_at AND NEW.deleted_at IS NOT NULL)
 EXECUTE FUNCTION hard_delete_user_details();
 
--- Update updated_at timestamp on user
-CREATE OR REPLACE FUNCTION update_user_timestamp()
+-- Update updated_at timestamp (shared for all tables with updated_at)
+CREATE OR REPLACE FUNCTION update_timestamp()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = CURRENT_TIMESTAMP;
@@ -290,66 +284,30 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER trigger_update_user_timestamp
 BEFORE UPDATE ON "user"
 FOR EACH ROW
-EXECUTE FUNCTION update_user_timestamp();
-
--- Update updated_at timestamp on user_details
-CREATE OR REPLACE FUNCTION update_user_details_timestamp()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = CURRENT_TIMESTAMP;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+EXECUTE FUNCTION update_timestamp();
 
 CREATE TRIGGER trigger_update_user_details_timestamp
 BEFORE UPDATE ON user_details
 FOR EACH ROW
-EXECUTE FUNCTION update_user_details_timestamp();
-
--- Update updated_at timestamp on tournament
-CREATE OR REPLACE FUNCTION update_tournament_timestamp()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = CURRENT_TIMESTAMP;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+EXECUTE FUNCTION update_timestamp();
 
 CREATE TRIGGER trigger_update_tournament_timestamp
 BEFORE UPDATE ON tournament
 FOR EACH ROW
-EXECUTE FUNCTION update_tournament_timestamp();
-
--- Update updated_at timestamp on team
-CREATE OR REPLACE FUNCTION update_team_timestamp()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = CURRENT_TIMESTAMP;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+EXECUTE FUNCTION update_timestamp();
 
 CREATE TRIGGER trigger_update_team_timestamp
 BEFORE UPDATE ON team
 FOR EACH ROW
-EXECUTE FUNCTION update_team_timestamp();
-
--- Update updated_at timestamp on match
-CREATE OR REPLACE FUNCTION update_match_timestamp()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = CURRENT_TIMESTAMP;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+EXECUTE FUNCTION update_timestamp();
 
 CREATE TRIGGER trigger_update_match_timestamp
 BEFORE UPDATE ON match
 FOR EACH ROW
-EXECUTE FUNCTION update_match_timestamp();
+EXECUTE FUNCTION update_timestamp();
 
 -- ============================================================================
--- 13. VERIFY SCHEMA
+-- 12. VERIFY SCHEMA
 -- ============================================================================
 
 -- Verify all tables created successfully

--- a/db/init_db.sql
+++ b/db/init_db.sql
@@ -1,5 +1,11 @@
 -- ============================================================================
--- 1. CREATE ENUM TYPES
+-- 1. CREATE EXTENSIONS FOR UUID SUPPORT
+-- ============================================================================
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ============================================================================
+-- 2. CREATE ENUM TYPES
 -- ============================================================================
 
 CREATE TYPE tournament_status AS ENUM (
@@ -10,11 +16,11 @@ CREATE TYPE tournament_status AS ENUM (
 );
 
 -- ============================================================================
--- 2. CREATE ACCOUNT_STATE TABLE (Lookup)
+-- 3. CREATE ACCOUNT_STATE TABLE (Lookup)
 -- ============================================================================
 
 CREATE TABLE account_state (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     name VARCHAR(50) NOT NULL UNIQUE,
     description VARCHAR(255),
     is_active BOOLEAN DEFAULT true,
@@ -29,15 +35,15 @@ INSERT INTO account_state (name, description) VALUES
     ('banned', 'User account is banned');
 
 -- ============================================================================
--- 3. CREATE USER TABLE (with soft delete & audit trail)
+-- 4. CREATE USER TABLE (with soft delete & audit trail)
 -- ============================================================================
 
 CREATE TABLE "user" (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     full_name VARCHAR(255) NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     is_organizer BOOLEAN DEFAULT false,
-    account_state_id INTEGER NOT NULL REFERENCES account_state(id),
+    account_state_id UUID NOT NULL REFERENCES account_state(id),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL
@@ -52,14 +58,14 @@ CREATE INDEX idx_user_is_organizer ON "user"(is_organizer);
 CREATE INDEX idx_user_deleted_at ON "user"(deleted_at);
 
 -- ============================================================================
--- 4. CREATE USER_DETAILS TABLE (Optional, cascade hard-delete with user)
+-- 5. CREATE USER_DETAILS TABLE (Optional, cascade hard-delete with user)
 -- ============================================================================
 
 CREATE TABLE user_details (
-    id SERIAL PRIMARY KEY,
-    user_id INTEGER NOT NULL UNIQUE REFERENCES "user"(id) ON DELETE CASCADE,
-    email VARCHAR(255) UNIQUE,
-    date_of_birth DATE,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL UNIQUE REFERENCES "user"(id) ON DELETE CASCADE,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    date_of_birth DATE NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -68,12 +74,12 @@ CREATE INDEX idx_user_details_user_id ON user_details(user_id);
 CREATE INDEX idx_user_details_email ON user_details(email);
 
 -- ============================================================================
--- 5. CREATE USER_PHONE TABLE (Multiple phones per user, cascade hard-delete)
+-- 6. CREATE USER_PHONE TABLE (Multiple phones per user, cascade hard-delete)
 -- ============================================================================
 
 CREATE TABLE user_phone (
-    id SERIAL PRIMARY KEY,
-    user_id INTEGER NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
     phone_number VARCHAR(20) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL
@@ -83,25 +89,37 @@ CREATE INDEX idx_user_phone_user_id ON user_phone(user_id);
 CREATE INDEX idx_user_phone_phone_number ON user_phone(phone_number);
 
 -- ============================================================================
--- 6. CREATE TOURNAMENT_THEME TABLE (Lookup)
+-- 7. CREATE TOURNAMENT_THEME TABLE (Lookup)
 -- ============================================================================
 
 CREATE TABLE tournament_theme (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     name VARCHAR(100) NOT NULL UNIQUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Insert default themes
+INSERT INTO tournament_theme (name) VALUES
+    ('Football'),
+    ('Basketball'),
+    ('Volleyball'),
+    ('Tennis'),
+    ('Chess'),
+    ('Badminton'),
+    ('Table Tennis'),
+    ('Esports');
+
 -- ============================================================================
--- 7. CREATE TOURNAMENT TABLE (with soft delete & audit trail)
+-- 8. CREATE TOURNAMENT TABLE (with background_img, soft delete & audit trail)
 -- ============================================================================
 
 CREATE TABLE tournament (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     name VARCHAR(255) NOT NULL,
-    organizer_id INTEGER REFERENCES "user"(id) ON DELETE SET NULL,
+    organizer_id UUID REFERENCES "user"(id) ON DELETE SET NULL,
+    theme_id UUID NOT NULL REFERENCES tournament_theme(id),
     max_teams INTEGER NOT NULL,
-    theme_id INTEGER NOT NULL REFERENCES tournament_theme(id),
+    background_img TEXT,
     start_date TIMESTAMP NOT NULL,
     registration_deadline TIMESTAMP NOT NULL,
     end_date TIMESTAMP NOT NULL,
@@ -111,22 +129,24 @@ CREATE TABLE tournament (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT valid_registration_deadline CHECK (registration_deadline <= start_date),
-    CONSTRAINT valid_end_date CHECK (end_date >= start_date)
+    CONSTRAINT valid_end_date CHECK (end_date >= start_date),
+    CONSTRAINT valid_max_teams CHECK (max_teams >= 2 AND max_teams <= 1024)
 );
 
 CREATE INDEX idx_tournament_organizer_id ON tournament(organizer_id);
 CREATE INDEX idx_tournament_theme_id ON tournament(theme_id);
 CREATE INDEX idx_tournament_status ON tournament(status);
 CREATE INDEX idx_tournament_start_date ON tournament(start_date);
+CREATE INDEX idx_tournament_registration_deadline ON tournament(registration_deadline);
 
 -- ============================================================================
--- 8. CREATE TEAM TABLE (Tournament-scoped, immutable deletion)
+-- 9. CREATE TEAM TABLE (Tournament-scoped, deletable)
 -- ============================================================================
 
 CREATE TABLE team (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     name VARCHAR(255) NOT NULL,
-    tournament_id INTEGER NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
+    tournament_id UUID NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
     is_disqualified BOOLEAN DEFAULT false,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -137,13 +157,13 @@ CREATE INDEX idx_team_tournament_id ON team(tournament_id);
 CREATE INDEX idx_team_is_disqualified ON team(is_disqualified);
 
 -- ============================================================================
--- 9. CREATE USER_TEAM TABLE (Junction, immutable membership)
+-- 10. CREATE USER_TEAM TABLE (Junction, immutable membership)
 -- ============================================================================
 
 CREATE TABLE user_team (
-    id SERIAL PRIMARY KEY,
-    user_id INTEGER NOT NULL REFERENCES "user"(id),
-    team_id INTEGER NOT NULL REFERENCES team(id) ON DELETE CASCADE,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+    team_id UUID NOT NULL REFERENCES team(id) ON DELETE CASCADE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_user_team UNIQUE (user_id, team_id)
 );
@@ -152,15 +172,15 @@ CREATE INDEX idx_user_team_user_id ON user_team(user_id);
 CREATE INDEX idx_user_team_team_id ON user_team(team_id);
 
 -- ============================================================================
--- 10. CREATE MATCH TABLE (Immutable, single elimination)
+-- 11. CREATE MATCH TABLE (Immutable, single elimination)
 -- ============================================================================
 
 CREATE TABLE match (
-    id SERIAL PRIMARY KEY,
-    tournament_id INTEGER NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
-    team_a_id INTEGER NOT NULL REFERENCES team(id),
-    team_b_id INTEGER NOT NULL REFERENCES team(id),
-    winner_id INTEGER REFERENCES team(id),
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    tournament_id UUID NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
+    team_a_id UUID NOT NULL REFERENCES team(id) ON DELETE CASCADE,
+    team_b_id UUID REFERENCES team(id) ON DELETE SET NULL,
+    winner_id UUID REFERENCES team(id) ON DELETE SET NULL,
     level INTEGER NOT NULL,
     order_number INTEGER NOT NULL,
     start_date TIMESTAMP,
@@ -171,7 +191,8 @@ CREATE TABLE match (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_match_position UNIQUE (tournament_id, level, order_number),
     CONSTRAINT valid_different_teams CHECK (team_a_id != team_b_id),
-    CONSTRAINT valid_winner CHECK (winner_id IS NULL OR winner_id IN (team_a_id, team_b_id))
+    CONSTRAINT valid_winner CHECK (winner_id IS NULL OR winner_id IN (team_a_id, team_b_id)),
+    CONSTRAINT valid_scores CHECK (team_a_score >= 0 AND team_b_score >= 0)
 );
 
 CREATE INDEX idx_match_tournament_id ON match(tournament_id);
@@ -179,23 +200,11 @@ CREATE INDEX idx_match_team_a_id ON match(team_a_id);
 CREATE INDEX idx_match_team_b_id ON match(team_b_id);
 CREATE INDEX idx_match_winner_id ON match(winner_id);
 CREATE INDEX idx_match_is_valid ON match(is_valid);
+CREATE INDEX idx_match_level ON match(level);
 
 -- ============================================================================
--- 11. CREATE TRIGGERS (Optional, for immutability enforcement)
+-- 12. CREATE TRIGGERS (Immutability enforcement, audit & GDPR compliance)
 -- ============================================================================
-
--- Prevent team deletion
-CREATE OR REPLACE FUNCTION prevent_team_deletion()
-RETURNS TRIGGER AS $$
-BEGIN
-    RAISE EXCEPTION 'Teams cannot be deleted. Mark as disqualified instead.';
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER trigger_prevent_team_deletion
-BEFORE DELETE ON team
-FOR EACH ROW
-EXECUTE FUNCTION prevent_team_deletion();
 
 -- Prevent match deletion
 CREATE OR REPLACE FUNCTION prevent_match_deletion()
@@ -222,6 +231,29 @@ CREATE TRIGGER trigger_prevent_user_team_deletion
 BEFORE DELETE ON user_team
 FOR EACH ROW
 EXECUTE FUNCTION prevent_user_team_deletion();
+
+-- Prevent team deletion in active tournaments
+CREATE OR REPLACE FUNCTION prevent_active_tournament_team_deletion()
+RETURNS TRIGGER AS $$
+DECLARE
+    tournament_status tournament_status;
+BEGIN
+    SELECT status INTO tournament_status
+    FROM tournament
+    WHERE id = OLD.tournament_id;
+    
+    IF tournament_status IN ('IN_PROGRESS', 'COMPLETED') THEN
+        RAISE EXCEPTION 'Cannot delete teams from active or completed tournaments';
+    END IF;
+    
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_prevent_active_tournament_team_deletion
+BEFORE DELETE ON team
+FOR EACH ROW
+EXECUTE FUNCTION prevent_active_tournament_team_deletion();
 
 -- Hard-delete user_phone on user soft-delete (GDPR compliance)
 CREATE OR REPLACE FUNCTION hard_delete_user_phones()
@@ -253,8 +285,8 @@ FOR EACH ROW
 WHEN (OLD.deleted_at IS DISTINCT FROM NEW.deleted_at AND NEW.deleted_at IS NOT NULL)
 EXECUTE FUNCTION hard_delete_user_details();
 
--- Update updated_at timestamp
-CREATE OR REPLACE FUNCTION update_timestamp()
+-- Update updated_at timestamp on user
+CREATE OR REPLACE FUNCTION update_user_timestamp()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = CURRENT_TIMESTAMP;
@@ -265,24 +297,69 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER trigger_update_user_timestamp
 BEFORE UPDATE ON "user"
 FOR EACH ROW
-EXECUTE FUNCTION update_timestamp();
+EXECUTE FUNCTION update_user_timestamp();
+
+-- Update updated_at timestamp on user_details
+CREATE OR REPLACE FUNCTION update_user_details_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trigger_update_user_details_timestamp
 BEFORE UPDATE ON user_details
 FOR EACH ROW
-EXECUTE FUNCTION update_timestamp();
+EXECUTE FUNCTION update_user_details_timestamp();
+
+-- Update updated_at timestamp on tournament
+CREATE OR REPLACE FUNCTION update_tournament_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trigger_update_tournament_timestamp
 BEFORE UPDATE ON tournament
 FOR EACH ROW
-EXECUTE FUNCTION update_timestamp();
+EXECUTE FUNCTION update_tournament_timestamp();
+
+-- Update updated_at timestamp on team
+CREATE OR REPLACE FUNCTION update_team_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trigger_update_team_timestamp
 BEFORE UPDATE ON team
 FOR EACH ROW
-EXECUTE FUNCTION update_timestamp();
+EXECUTE FUNCTION update_team_timestamp();
+
+-- Update updated_at timestamp on match
+CREATE OR REPLACE FUNCTION update_match_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trigger_update_match_timestamp
 BEFORE UPDATE ON match
 FOR EACH ROW
-EXECUTE FUNCTION update_timestamp();
+EXECUTE FUNCTION update_match_timestamp();
+
+-- ============================================================================
+-- 13. VERIFY SCHEMA
+-- ============================================================================
+
+-- Verify all tables created successfully
+SELECT tablename FROM pg_tables 
+WHERE schemaname = 'public' 
+ORDER BY tablename;

--- a/db/init_db.sql
+++ b/db/init_db.sql
@@ -100,14 +100,11 @@ CREATE TABLE tournament_theme (
 
 -- Insert default themes
 INSERT INTO tournament_theme (name) VALUES
-    ('Football'),
-    ('Basketball'),
-    ('Volleyball'),
-    ('Tennis'),
     ('Chess'),
-    ('Badminton'),
-    ('Table Tennis'),
-    ('Esports');
+    ('Tennis'),
+    ('Shooting'),
+    ('Boxing'),
+    ('Rocket League');
 
 -- ============================================================================
 -- 8. CREATE TOURNAMENT TABLE (with background_img, soft delete & audit trail)

--- a/db/init_db.sql
+++ b/db/init_db.sql
@@ -49,10 +49,6 @@ CREATE TABLE "user" (
     deleted_at TIMESTAMP NULL
 );
 
-CREATE UNIQUE INDEX idx_user_email_not_deleted 
-ON "user" (id) 
-WHERE deleted_at IS NULL;
-
 CREATE INDEX idx_user_account_state_id ON "user"(account_state_id);
 CREATE INDEX idx_user_is_organizer ON "user"(is_organizer);
 CREATE INDEX idx_user_deleted_at ON "user"(deleted_at);
@@ -162,8 +158,8 @@ CREATE INDEX idx_team_is_disqualified ON team(is_disqualified);
 
 CREATE TABLE user_team (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
-    team_id UUID NOT NULL REFERENCES team(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE RESTRICT,
+    team_id UUID NOT NULL REFERENCES team(id) ON DELETE RESTRICT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT unique_user_team UNIQUE (user_id, team_id)
 );
@@ -178,7 +174,7 @@ CREATE INDEX idx_user_team_team_id ON user_team(team_id);
 CREATE TABLE match (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tournament_id UUID NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
-    team_a_id UUID NOT NULL REFERENCES team(id) ON DELETE CASCADE,
+    team_a_id UUID NOT NULL REFERENCES team(id) ON DELETE RESTRICT,
     team_b_id UUID REFERENCES team(id) ON DELETE SET NULL,
     winner_id UUID REFERENCES team(id) ON DELETE SET NULL,
     level INTEGER NOT NULL,
@@ -236,13 +232,13 @@ EXECUTE FUNCTION prevent_user_team_deletion();
 CREATE OR REPLACE FUNCTION prevent_active_tournament_team_deletion()
 RETURNS TRIGGER AS $$
 DECLARE
-    tournament_status tournament_status;
+    v_status tournament_status;
 BEGIN
-    SELECT status INTO tournament_status
+    SELECT status INTO v_status
     FROM tournament
     WHERE id = OLD.tournament_id;
     
-    IF tournament_status IN ('IN_PROGRESS', 'COMPLETED') THEN
+    IF v_status IN ('IN_PROGRESS', 'COMPLETED') THEN
         RAISE EXCEPTION 'Cannot delete teams from active or completed tournaments';
     END IF;
     


### PR DESCRIPTION
Several structural issues in `db/init_db.sql` that would cause runtime failures or silent data integrity bugs.

## Changes

- **`gen_random_uuid()` replaces `uuid_generate_v4()`** — drops the `uuid-ossp` extension dependency; `gen_random_uuid()` is built into PostgreSQL 13+ core with no elevated privileges required

- **NULL-safe `valid_winner` CHECK** — `IN (team_a_id, team_b_id)` is unsafe when `team_b_id IS NULL`: SQL `IN` with a NULL list member evaluates to `NULL` not `FALSE`, silently passing invalid winner values
  ```sql
  -- Before (unsafe)
  CONSTRAINT valid_winner CHECK (winner_id IS NULL OR winner_id IN (team_a_id, team_b_id))

  -- After (NULL-safe)
  CONSTRAINT valid_winner CHECK (winner_id IS NULL OR winner_id = team_a_id OR (team_b_id IS NOT NULL AND winner_id = team_b_id))
  ```

- **`ON DELETE CASCADE` → `RESTRICT` on `user_team` and `match.team_a_id`** — cascade deletes would attempt row deletion and immediately error at the immutability triggers (`prevent_user_team_deletion`, `prevent_match_deletion`); `RESTRICT` enforces intent at the FK level

- **Shared `update_timestamp()` trigger function** — consolidated 5 identical per-table functions into one reused across all tables

- **Removed redundant `idx_user_email_not_deleted` index** — was indexing `id` (already PK); name implied email uniqueness but `email` lives in `user_details`

- **Fixed variable shadowing enum type** — renamed local var `tournament_status tournament_status` → `v_status tournament_status` in `prevent_active_tournament_team_deletion`