### PR TITLE
DEV-320 [API] Некоректний ключ ролі у JWT-токені

### DIFF
--- a/server/TournamentPlatformSystemWebApi.Infrastructure/Security/JwtTokenService.cs
+++ b/server/TournamentPlatformSystemWebApi.Infrastructure/Security/JwtTokenService.cs
@@ -28,7 +28,7 @@ namespace TournamentPlatformSystemWebApi.Infrastructure.Security
             var claims = new[] {
                 new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
                 new Claim(JwtRegisteredClaimNames.Email, email),
-                new Claim(ClaimTypes.Role, role ?? string.Empty),
+                new Claim("role", role),
                 new Claim("isOrganizer", isOrganizer.ToString())
             };
 


### PR DESCRIPTION
## 📝 Опис


This pull request makes a small change to the way user roles are stored in JWT claims. Specifically, it updates the claim type for roles from the default `ClaimTypes.Role` to a custom `"role"` string. This may improve compatibility or clarity when consuming the token.

* Changed the role claim in JWT generation from `ClaimTypes.Role` to a custom `"role"` string in `JwtTokenService.cs`.

## 🏷️ Тип зміни

<!-- Виберіть відповідний тип -->
- [x] Bug fix (виправлення помилки)
- [ ] Feature (нова функціональність)
- [ ] Refactoring (переробка коду)
- [ ] Documentation (документація)
- [ ] UI/UX (оформлення)
- [ ] Performance (оптимізація)
- [ ] Tests (тестування)

##  Task Link

<!-- Посилання на завдання в Jira -->
- Task: [DEV-320](https://tournamentsystem.atlassian.net/browse/DEV-320)







[DEV-320]: https://tournamentsystem.atlassian.net/browse/DEV-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ