### PR TITLE
[frontend][DEV-319][DEV-323] Fix login rate limit handling and rememberMe payload

### DIFF
--- a/client/src/components/forms/LoginForm.vue
+++ b/client/src/components/forms/LoginForm.vue
@@ -114,7 +114,11 @@
         <span class="login-form__forgot">Forgot password?</span>
       </div>
 
-      <button type="submit" class="login-form__submit" :disabled="isSubmitting">
+      <button
+        type="submit"
+        class="login-form__submit"
+        :disabled="isSubmitting || isLoginBlocked"
+      >
         {{ isSubmitting ? 'Logging In...' : 'Log In' }}
       </button>
 
@@ -163,6 +167,7 @@ type FormErrors = Partial<Record<keyof ILoginFormValues, string>>;
 const router = useRouter();
 const route = useRoute();
 const authStore = useAuthStore();
+const isLoginBlocked = ref(false);
 
 const form = reactive<ILoginFormValues>({
   email: localStorage.getItem('login_email') ?? '',
@@ -251,6 +256,7 @@ const handleSubmit = async () => {
     const response = await authStore.login({
       email: form.email,
       password: form.password,
+      rememberMe: form.rememberMe,
     });
 
     const redirectPath =
@@ -268,6 +274,17 @@ const handleSubmit = async () => {
 
     if (apiError.errorCode === 'INVALID_CREDENTIALS') {
       submitError.value = 'Invalid email or password';
+    } else if (apiError.errorCode === 'TOO_MANY_ATTEMPTS') {
+      submitError.value =
+        apiError.message ?? 'Too many failed login attempts. Try again later.';
+      isLoginBlocked.value = true;
+      window.setTimeout(
+        () => {
+          isLoginBlocked.value = false;
+          submitError.value = '';
+        },
+        5 * 60 * 1000,
+      );
     } else if (apiError.errorCode === 'ACCOUNT_LOCKED') {
       submitError.value = 'Account is locked. Please contact support.';
     } else if (apiError.errorCode === 'VALIDATION_ERROR') {

--- a/client/src/components/forms/LoginForm.vue
+++ b/client/src/components/forms/LoginForm.vue
@@ -19,12 +19,14 @@
 
           <input
             id="email"
+            ref="emailInput"
             v-model.trim="form.email"
             type="email"
             class="login-form__input"
             placeholder="Enter your email"
             autocomplete="email"
             @blur="validateField('email')"
+            @input="validateField('email')"
           />
         </div>
 
@@ -59,12 +61,14 @@
 
           <input
             id="password"
+            ref="passwordInput"
             v-model="form.password"
             :type="showPassword ? 'text' : 'password'"
             class="login-form__input login-form__input--password"
             placeholder="Enter your password"
             autocomplete="current-password"
             @blur="validateField('password')"
+            @input="validateField('password')"
           />
 
           <button
@@ -139,6 +143,7 @@
         </p>
       </div>
 
+      <p v-if="toastMessage" class="login-form__toast">{{ toastMessage }}</p>
       <p v-if="submitError" class="login-form__submit-error">{{ submitError }}</p>
     </div>
   </form>
@@ -158,8 +163,9 @@ type FormErrors = Partial<Record<keyof ILoginFormValues, string>>;
 const router = useRouter();
 const route = useRoute();
 const authStore = useAuthStore();
+
 const form = reactive<ILoginFormValues>({
-  email: '',
+  email: localStorage.getItem('login_email') ?? '',
   password: '',
   rememberMe: true,
 });
@@ -167,9 +173,33 @@ const form = reactive<ILoginFormValues>({
 const errors = reactive<FormErrors>({});
 const isSubmitting = ref(false);
 const submitError = ref('');
+const toastMessage = ref('');
 const showPassword = ref(false);
 
+const emailInput = ref<HTMLInputElement | null>(null);
+const passwordInput = ref<HTMLInputElement | null>(null);
+
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const focusFirstError = () => {
+  if (errors.email) {
+    emailInput.value?.focus();
+    return;
+  }
+
+  if (errors.password) {
+    passwordInput.value?.focus();
+  }
+};
+
+const applyBackendErrors = (fieldErrors?: Record<string, string>) => {
+  if (!fieldErrors) return;
+
+  if (fieldErrors.email) errors.email = fieldErrors.email;
+  if (fieldErrors.password) errors.password = fieldErrors.password;
+
+  focusFirstError();
+};
 
 const validateField = (field: keyof ILoginFormValues) => {
   switch (field) {
@@ -181,6 +211,7 @@ const validateField = (field: keyof ILoginFormValues) => {
       } else {
         errors.email = '';
       }
+      localStorage.setItem('login_email', form.email);
       break;
 
     case 'password':
@@ -205,16 +236,21 @@ const validateForm = () => {
 
 const handleSubmit = async () => {
   submitError.value = '';
+  toastMessage.value = '';
 
   const isValid = validateForm();
-  if (!isValid) return;
+
+  if (!isValid) {
+    focusFirstError();
+    return;
+  }
 
   isSubmitting.value = true;
 
   try {
     const response = await authStore.login({
-    email: form.email,
-    password: form.password,
+      email: form.email,
+      password: form.password,
     });
 
     const redirectPath =
@@ -224,16 +260,22 @@ const handleSubmit = async () => {
 
     await router.push(redirectPath);
   } catch (error: unknown) {
-    const apiError = error as { errorCode?: string; message?: string };
+    const apiError = error as {
+      errorCode?: string;
+      message?: string;
+      fieldErrors?: Record<string, string>;
+    };
 
     if (apiError.errorCode === 'INVALID_CREDENTIALS') {
       submitError.value = 'Invalid email or password';
     } else if (apiError.errorCode === 'ACCOUNT_LOCKED') {
       submitError.value = 'Account is locked. Please contact support.';
     } else if (apiError.errorCode === 'VALIDATION_ERROR') {
+      applyBackendErrors(apiError.fieldErrors);
       submitError.value = apiError.message ?? 'Validation error';
     } else {
-      submitError.value = 'Server error. Please try again later.';
+      toastMessage.value = 'Помилка сервера';
+      submitError.value = apiError.message ?? 'Server error. Please try again later.';
     }
   } finally {
     isSubmitting.value = false;
@@ -242,7 +284,6 @@ const handleSubmit = async () => {
 </script>
 
 <style scoped>
-
 .login-form__input:-webkit-autofill,
 .login-form__input:-webkit-autofill:hover,
 .login-form__input:-webkit-autofill:focus {
@@ -388,12 +429,12 @@ const handleSubmit = async () => {
   display: none;
 }
 
-.login-form__input[type="password"]::-webkit-credentials-auto-fill-button,
-.login-form__input[type="password"]::-webkit-textfield-decoration-container {
+.login-form__input[type='password']::-webkit-credentials-auto-fill-button,
+.login-form__input[type='password']::-webkit-textfield-decoration-container {
   display: none !important;
 }
 
-input[type="password"]::-webkit-credentials-auto-fill-button {
+input[type='password']::-webkit-credentials-auto-fill-button {
   visibility: hidden;
   display: none !important;
 }
@@ -451,23 +492,6 @@ input[type="password"]::-webkit-credentials-auto-fill-button {
   font-size: 15px;
   font-weight: 700;
   cursor: pointer;
-  transition:
-    background 0.2s ease,
-    color 0.2s ease,
-    border-color 0.2s ease;
-}
-
-.login-form__submit:hover {
-  background: #ff9800;
-  color: #fffcf2;
-}
-
-.login-form__submit:active,
-.login-form__submit:focus-visible {
-  background: transparent;
-  color: #ff9800;
-  border-color: #ff9800;
-  outline: none;
 }
 
 .login-form__submit:disabled {
@@ -523,18 +547,6 @@ input[type="password"]::-webkit-credentials-auto-fill-button {
   font-size: 15px;
   font-weight: 700;
   text-decoration: none;
-  transition:
-    background 0.2s ease,
-    color 0.2s ease,
-    border-color 0.2s ease;
-}
-
-.login-form__create-account:active,
-.login-form__create-account:focus-visible {
-  background: #1531CE;
-  border-color: #1531CE;
-  color: #fffcf2;
-  outline: none;
 }
 
 .login-form__privacy {
@@ -569,17 +581,27 @@ input[type="password"]::-webkit-credentials-auto-fill-button {
   opacity: 0.9;
 }
 
+.login-form__toast,
 .login-form__submit-error {
   width: 433px;
   max-width: 100%;
-  margin: 22px 0 0;
-  border: 1px solid rgba(255, 107, 107, 0.45);
+  margin: 18px 0 0;
   border-radius: 12px;
-  background: rgba(255, 107, 107, 0.12);
-  color: #ff6b6b;
   padding: 14px 16px;
   font-size: 14px;
   line-height: 1.5;
+}
+
+.login-form__toast {
+  border: 1px solid rgba(255, 152, 0, 0.45);
+  background: rgba(255, 152, 0, 0.12);
+  color: #ff9800;
+}
+
+.login-form__submit-error {
+  border: 1px solid rgba(255, 107, 107, 0.45);
+  background: rgba(255, 107, 107, 0.12);
+  color: #ff6b6b;
 }
 
 @media (max-width: 640px) {

--- a/client/src/components/forms/RegisterForm.vue
+++ b/client/src/components/forms/RegisterForm.vue
@@ -10,7 +10,10 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="fullName">Name &amp; Surname</label>
-        <div class="register-form__input-wrapper">
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.fullName }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path
@@ -29,12 +32,14 @@
 
           <input
             id="fullName"
+            ref="fullNameInput"
             v-model.trim="form.fullName"
             type="text"
             class="register-form__input"
-            placeholder="Enter your full name"
+            placeholder="Enter first and last name"
             maxlength="255"
             @blur="validateField('fullName')"
+            @input="validateField('fullName')"
           />
         </div>
         <p class="register-form__error">{{ errors.fullName || '' }}</p>
@@ -42,7 +47,10 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="phoneNumber">Phone</label>
-        <div class="register-form__input-wrapper">
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.phoneNumber }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path
@@ -56,20 +64,24 @@
 
           <input
             id="phoneNumber"
+            ref="phoneInput"
             :value="form.phoneNumber"
-            @input="handlePhoneInput"
             type="tel"
             class="register-form__input"
             placeholder="+380 XX XXX XX XX"
+            @input="handlePhoneInput"
             @blur="validateField('phoneNumber')"
           />
-          </div>
+        </div>
         <p class="register-form__error">{{ errors.phoneNumber || '' }}</p>
       </div>
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="email">Email</label>
-        <div class="register-form__input-wrapper">
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.email }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path
@@ -89,10 +101,12 @@
 
           <input
             id="email"
+            ref="emailInput"
             v-model.trim="form.email"
             type="email"
             class="register-form__input"
             placeholder="example@email.com"
+            @input="validateField('email')"
             @blur="handleEmailBlur"
           />
         </div>
@@ -113,17 +127,15 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="dateOfBirth">Date of birth</label>
-        <div class="register-form__input-wrapper register-form__input-wrapper--date">
+        <div
+          class="register-form__input-wrapper register-form__input-wrapper--date"
+          :class="{ 'register-form__input-wrapper--error': errors.dateOfBirth }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path d="M7 2V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
               <path d="M17 2V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-              <path
-                d="M4 9H20"
-                stroke="currentColor"
-                stroke-width="1.8"
-                stroke-linecap="round"
-              />
+              <path d="M4 9H20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
               <rect
                 x="4"
                 y="4"
@@ -138,22 +150,19 @@
 
           <input
             id="dateOfBirth"
+            ref="dateOfBirthInput"
             v-model="form.dateOfBirth"
             type="date"
             class="register-form__input register-form__input--date"
             @blur="validateField('dateOfBirth')"
+            @change="validateField('dateOfBirth')"
           />
 
           <span class="register-form__date-icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path d="M7 2V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
               <path d="M17 2V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-              <path
-                d="M4 9H20"
-                stroke="currentColor"
-                stroke-width="1.8"
-                stroke-linecap="round"
-              />
+              <path d="M4 9H20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
               <rect
                 x="4"
                 y="4"
@@ -182,6 +191,7 @@
               type="radio"
               value="organizer"
               class="register-form__radio"
+              @change="validateField('role')"
             />
             <span class="register-form__role-check"></span>
 
@@ -227,6 +237,7 @@
               type="radio"
               value="player"
               class="register-form__radio"
+              @change="validateField('role')"
             />
             <span class="register-form__role-check"></span>
 
@@ -253,7 +264,10 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="password">Password</label>
-        <div class="register-form__input-wrapper">
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.password }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <rect
@@ -275,6 +289,7 @@
 
           <input
             id="password"
+            ref="passwordInput"
             v-model="form.password"
             :type="showPassword ? 'text' : 'password'"
             class="register-form__input register-form__input--password"
@@ -328,7 +343,10 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="confirmPassword">Confirm Password</label>
-        <div class="register-form__input-wrapper">
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.confirmPassword }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <rect
@@ -350,10 +368,12 @@
 
           <input
             id="confirmPassword"
+            ref="confirmPasswordInput"
             v-model="form.confirmPassword"
             :type="showConfirmPassword ? 'text' : 'password'"
             class="register-form__input register-form__input--password"
             placeholder="Repeat password"
+            @input="validateField('confirmPassword')"
             @blur="validateField('confirmPassword')"
           />
 
@@ -387,6 +407,7 @@
             </svg>
           </button>
         </div>
+
         <p class="register-form__error">{{ errors.confirmPassword || '' }}</p>
       </div>
 
@@ -425,6 +446,7 @@
         </div>
       </div>
 
+      <p v-if="toastMessage" class="register-form__toast">{{ toastMessage }}</p>
       <p v-if="submitError" class="register-form__submit-error">{{ submitError }}</p>
       <p v-if="submitSuccess" class="register-form__submit-success">
         Registration successful. Redirecting...
@@ -438,9 +460,7 @@ import { computed, reactive, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { authService } from '../../services/authService';
 import { useAuthStore } from '../../stores/authStore';
-
 import type { IApiError, IRegisterFormValues, IRegisterRequest } from '../../types/Auth';
-
 
 type FormErrors = Partial<Record<keyof IRegisterFormValues, string>>;
 
@@ -448,11 +468,13 @@ const router = useRouter();
 const authStore = useAuthStore();
 
 const form = reactive<IRegisterFormValues>({
-  fullName: '',
-  phoneNumber: '+380',
-  email: '',
-  dateOfBirth: '',
-  role: 'organizer',
+  fullName: localStorage.getItem('register_fullName') ?? '',
+  phoneNumber: localStorage.getItem('register_phoneNumber') ?? '+380',
+  email: localStorage.getItem('register_email') ?? '',
+  dateOfBirth: localStorage.getItem('register_dateOfBirth') ?? '',
+  role:
+    (localStorage.getItem('register_role') as IRegisterFormValues['role'] | null) ??
+    'organizer',
   password: '',
   confirmPassword: '',
 });
@@ -464,46 +486,43 @@ const emailIsUnique = ref<boolean | null>(null);
 const isSubmitting = ref(false);
 const submitError = ref('');
 const submitSuccess = ref(false);
+const toastMessage = ref('');
 
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 
+const fullNameInput = ref<HTMLInputElement | null>(null);
+const phoneInput = ref<HTMLInputElement | null>(null);
+const emailInput = ref<HTMLInputElement | null>(null);
+const dateOfBirthInput = ref<HTMLInputElement | null>(null);
+const passwordInput = ref<HTMLInputElement | null>(null);
+const confirmPasswordInput = ref<HTMLInputElement | null>(null);
 
 const formatPhone = (digits: string) => {
   let formatted = '+380';
 
-  if (digits.length > 0) {
-    formatted += ' ' + digits.substring(0, 2);
-  }
-  if (digits.length >= 3) {
-    formatted += ' ' + digits.substring(2, 5);
-  }
-  if (digits.length >= 6) {
-    formatted += ' ' + digits.substring(5, 7);
-  }
-  if (digits.length >= 8) {
-    formatted += ' ' + digits.substring(7, 9);
-  }
+  if (digits.length > 0) formatted += ` ${digits.substring(0, 2)}`;
+  if (digits.length >= 3) formatted += ` ${digits.substring(2, 5)}`;
+  if (digits.length >= 6) formatted += ` ${digits.substring(5, 7)}`;
+  if (digits.length >= 8) formatted += ` ${digits.substring(7, 9)}`;
 
   return formatted;
 };
 
 const handlePhoneInput = (event: Event) => {
   const input = event.target as HTMLInputElement;
-
   let digits = input.value.replace(/\D/g, '');
 
   if (!digits.startsWith('380')) {
-    digits = '380' + digits;
+    digits = `380${digits}`;
   }
 
-  digits = digits.substring(3);
-
-  digits = digits.substring(0, 9);
-
+  digits = digits.substring(3, 12);
   form.phoneNumber = formatPhone(digits);
-};
 
+  localStorage.setItem('register_phoneNumber', form.phoneNumber);
+  validateField('phoneNumber');
+};
 
 const fullNameRegex =
   /^[A-Za-zА-Яа-яІіЇїЄєҐґ'’-]+(?:\s+[A-Za-zА-Яа-яІіЇїЄєҐґ'’-]+){1,2}$/u;
@@ -536,9 +555,11 @@ const strengthClass = computed(() => {
   if (!form.password || passwordStrengthScore.value <= 2) {
     return 'register-form__strength-fill--weak';
   }
+
   if (passwordStrengthScore.value === 3) {
     return 'register-form__strength-fill--medium';
   }
+
   return 'register-form__strength-fill--strong';
 });
 
@@ -556,6 +577,45 @@ const getAge = (dateString: string) => {
   return age;
 };
 
+const focusFirstError = () => {
+  if (errors.fullName) return fullNameInput.value?.focus();
+  if (errors.phoneNumber) return phoneInput.value?.focus();
+  if (errors.email) return emailInput.value?.focus();
+  if (errors.dateOfBirth) return dateOfBirthInput.value?.focus();
+  if (errors.password) return passwordInput.value?.focus();
+  if (errors.confirmPassword) return confirmPasswordInput.value?.focus();
+
+  return undefined;
+};
+
+const applyBackendErrors = (fieldErrors?: Record<string, string>) => {
+  if (!fieldErrors) return;
+
+  Object.entries(fieldErrors).forEach(([field, message]) => {
+    if (field in errors) {
+      errors[field as keyof IRegisterFormValues] = message;
+    }
+  });
+
+  focusFirstError();
+};
+
+const saveFormDraft = () => {
+  localStorage.setItem('register_fullName', form.fullName);
+  localStorage.setItem('register_phoneNumber', form.phoneNumber);
+  localStorage.setItem('register_email', form.email);
+  localStorage.setItem('register_dateOfBirth', form.dateOfBirth);
+  localStorage.setItem('register_role', form.role);
+};
+
+const clearFormDraft = () => {
+  localStorage.removeItem('register_fullName');
+  localStorage.removeItem('register_phoneNumber');
+  localStorage.removeItem('register_email');
+  localStorage.removeItem('register_dateOfBirth');
+  localStorage.removeItem('register_role');
+};
+
 const validateField = (field: keyof IRegisterFormValues) => {
   switch (field) {
     case 'fullName':
@@ -568,6 +628,8 @@ const validateField = (field: keyof IRegisterFormValues) => {
       } else {
         errors.fullName = '';
       }
+
+      localStorage.setItem('register_fullName', form.fullName);
       break;
 
     case 'phoneNumber':
@@ -580,6 +642,8 @@ const validateField = (field: keyof IRegisterFormValues) => {
       } else {
         errors.phoneNumber = '';
       }
+
+      localStorage.setItem('register_phoneNumber', form.phoneNumber);
       break;
 
     case 'email':
@@ -590,6 +654,8 @@ const validateField = (field: keyof IRegisterFormValues) => {
       } else {
         errors.email = '';
       }
+
+      localStorage.setItem('register_email', form.email);
       break;
 
     case 'dateOfBirth':
@@ -600,6 +666,8 @@ const validateField = (field: keyof IRegisterFormValues) => {
       } else {
         errors.dateOfBirth = '';
       }
+
+      localStorage.setItem('register_dateOfBirth', form.dateOfBirth);
       break;
 
     case 'role':
@@ -608,6 +676,8 @@ const validateField = (field: keyof IRegisterFormValues) => {
       } else {
         errors.role = '';
       }
+
+      localStorage.setItem('register_role', form.role);
       break;
 
     case 'password':
@@ -666,6 +736,7 @@ const handleEmailBlur = async () => {
   }
 
   isCheckingEmail.value = true;
+
   try {
     const isUnique = await authService.checkEmailUnique(form.email.trim());
     emailIsUnique.value = isUnique;
@@ -691,9 +762,16 @@ const handlePasswordInput = () => {
 const handleSubmit = async () => {
   submitError.value = '';
   submitSuccess.value = false;
+  toastMessage.value = '';
+
+  saveFormDraft();
 
   const isValid = await validateForm();
-  if (!isValid) return;
+
+  if (!isValid) {
+    focusFirstError();
+    return;
+  }
 
   isSubmitting.value = true;
 
@@ -709,24 +787,25 @@ const handleSubmit = async () => {
 
     const response = await authService.register(payload);
 
-
     authStore.setAuth(response);
     submitSuccess.value = true;
+    clearFormDraft();
 
     setTimeout(() => {
       router.push(authStore.getDashboardRouteByRole(response.role));
     }, 900);
   } catch (error: unknown) {
-
     const apiError = error as IApiError;
-
 
     if (apiError.errorCode === 'EMAIL_TAKEN') {
       submitError.value = 'Email is already registered';
       errors.email = 'Email is already registered';
+      focusFirstError();
     } else if (apiError.errorCode === 'VALIDATION_ERROR') {
+      applyBackendErrors(apiError.fieldErrors);
       submitError.value = apiError.message ?? 'Validation error';
     } else {
+      toastMessage.value = 'Помилка сервера';
       submitError.value = apiError.message ?? 'Server error. Please try again later.';
     }
   } finally {
@@ -793,6 +872,10 @@ const handleSubmit = async () => {
 
 .register-form__input-wrapper {
   position: relative;
+}
+
+.register-form__input-wrapper--error .register-form__input {
+  border-color: #ff6b6b;
 }
 
 .register-form__input-wrapper--date {
@@ -1156,6 +1239,7 @@ const handleSubmit = async () => {
   opacity: 0.85;
 }
 
+.register-form__toast,
 .register-form__submit-error,
 .register-form__submit-success {
   margin: 18px 0 0;
@@ -1163,6 +1247,12 @@ const handleSubmit = async () => {
   padding: 14px 16px;
   font-size: 14px;
   line-height: 1.5;
+}
+
+.register-form__toast {
+  border: 1px solid rgba(255, 152, 0, 0.45);
+  background: rgba(255, 152, 0, 0.12);
+  color: #ff9800;
 }
 
 .register-form__submit-error {

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -154,6 +154,7 @@ class AuthService {
         const payload = {
             email: data.email.trim(),
             password: data.password,
+            rememberMe: data.rememberMe,
         };
 
         try {

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -6,6 +6,7 @@ import type {
     ILoginRequest,
     ILoginResponse,
     IRegisterRequest,
+    IRegisterResponse,
     UserRole,
 } from '../types/Auth';
 
@@ -21,9 +22,6 @@ type BackendErrorResponse = {
     errors?: Record<string, string[] | string>;
 };
 
-type BackendTokenOnlyResponse = {
-    token: string;
-};
 
 const normalizeRole = (role: string): UserRole => {
     return role.toLowerCase() === 'organizer' ? 'organizer' : 'player';
@@ -110,35 +108,26 @@ class AuthService {
         }
 
         try {
-            const response = await axiosInstance.post<
-                Partial<IAuthResponse> & BackendTokenOnlyResponse
-            >('/auth/register', payload);
-
+            const response = await axiosInstance.post<IRegisterResponse>('/auth/register', payload);
             const successBody = response.data;
 
-            if (!successBody.token) {
+            if (!successBody.tokens?.accessToken) {
                 throw {
                     errorCode: 'INVALID_RESPONSE',
-                    message: 'Token is missing in server response.',
+                    message: 'Access token is missing in server response.',
                 } satisfies IApiError;
             }
 
-            return {
-                userId:
-                    typeof successBody.userId === 'string'
-                        ? successBody.userId
-                        : crypto.randomUUID(),
-                email: typeof successBody.email === 'string' ? successBody.email : payload.email,
-                fullName:
-                    typeof successBody.fullName === 'string'
-                        ? successBody.fullName
-                        : payload.fullName,
-                role: normalizeRole(
-                    typeof successBody.role === 'string' ? successBody.role : payload.role,
-                ),
-                token: successBody.token,
-                refreshToken: successBody.refreshToken ?? null,
+            const result: IAuthResponse = {
+                userId: successBody.userId,
+                email: successBody.email,
+                fullName: successBody.fullName,
+                role: normalizeRole(successBody.role),
+                token: successBody.tokens.accessToken,
+                refreshToken: successBody.tokens.refreshToken ?? null,
             };
+
+            return result;
         } catch (error) {
             const apiError = handleAxiosError(error, 'Server error. Please try again later.');
 
@@ -202,5 +191,4 @@ class AuthService {
         return true;
     }
 }
-
 export const authService = new AuthService();

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -18,6 +18,7 @@ type BackendErrorResponse = {
         timestamp?: string;
         traceId?: string;
     };
+    errors?: Record<string, string[] | string>;
 };
 
 type BackendTokenOnlyResponse = {
@@ -31,6 +32,15 @@ const normalizeRole = (role: string): UserRole => {
 const toBackendRole = (role: string): 'organizer' | 'player' => {
     return role.toLowerCase() === 'organizer' ? 'organizer' : 'player';
 }; // [serhii] Бекенд чекає роль в lower case форматі. Виправив
+
+const normalizeFieldName = (field: string) => {
+    const normalized = field.charAt(0).toLowerCase() + field.slice(1);
+
+    if (normalized === 'phone') return 'phoneNumber';
+    if (normalized === 'name') return 'fullName';
+
+    return normalized;
+};
 
 const buildApiError = (
     status: number | undefined,
@@ -55,9 +65,18 @@ const buildApiError = (
         errorCode = data.error.type;
     }
 
+    const fieldErrors: Record<string, string> = {};
+
+    if (data?.errors) {
+        Object.entries(data.errors).forEach(([field, value]) => {
+            fieldErrors[normalizeFieldName(field)] = Array.isArray(value) ? value[0] : value;
+        });
+    }
+
     return {
         errorCode,
         message: data?.error?.message ?? fallbackMessage,
+        fieldErrors: Object.keys(fieldErrors).length ? fieldErrors : undefined,
     };
 };
 
@@ -71,6 +90,7 @@ const handleAxiosError = (error: unknown, fallbackMessage: string): IApiError =>
     return {
         errorCode: apiError.errorCode ?? 'INTERNAL_ERROR',
         message: apiError.message ?? fallbackMessage,
+        fieldErrors: apiError.fieldErrors,
     };
 };
 
@@ -96,14 +116,14 @@ class AuthService {
 
             const successBody = response.data;
 
-            if (!successBody.tokens.accessToken) {
+            if (!successBody.token) {
                 throw {
                     errorCode: 'INVALID_RESPONSE',
                     message: 'Token is missing in server response.',
                 } satisfies IApiError;
             }
 
-            const result: IAuthResponse = {
+            return {
                 userId:
                     typeof successBody.userId === 'string'
                         ? successBody.userId
@@ -116,14 +136,9 @@ class AuthService {
                 role: normalizeRole(
                     typeof successBody.role === 'string' ? successBody.role : payload.role,
                 ),
-                tokens: successBody.tokens
+                token: successBody.token,
+                refreshToken: successBody.refreshToken ?? null,
             };
-
-            if (import.meta.env.DEV) {
-                console.log('[authService] register response', result);
-            }
-
-            return result;
         } catch (error) {
             const apiError = handleAxiosError(error, 'Server error. Please try again later.');
 
@@ -141,13 +156,8 @@ class AuthService {
             password: data.password,
         };
 
-        if (import.meta.env.DEV) {
-            console.log('[authService] login request', { email: payload.email });
-        }
-
         try {
             const loginResponse = await axiosInstance.post<ILoginResponse>('/auth/login', payload);
-
             const loginResult = loginResponse.data;
 
             if (!loginResult.tokens?.accessToken) {
@@ -164,7 +174,7 @@ class AuthService {
                 } satisfies IApiError;
             }
 
-            const result: IAuthResponse = {
+            return {
                 userId: loginResult.user.id,
                 email: loginResult.user.email,
                 fullName: loginResult.user.fullName,
@@ -172,12 +182,6 @@ class AuthService {
                 token: loginResult.tokens.accessToken,
                 refreshToken: loginResult.tokens.refreshToken ?? null,
             };
-
-            if (import.meta.env.DEV) {
-                console.log('[authService] login response', result);
-            }
-
-            return result;
         } catch (error) {
             const apiError = handleAxiosError(error, 'Server error. Please try again later.');
 

--- a/client/src/types/Auth.ts
+++ b/client/src/types/Auth.ts
@@ -9,6 +9,17 @@ export interface IRegisterRequest {
     password: string;
 }
 
+export interface IRegisterResponse {
+    userId: string;
+    email: string;
+    fullName: string;
+    role: string;
+    tokens: {
+        accessToken: string;
+        refreshToken: string;
+    };
+}
+
 export interface IRegisterFormValues extends IRegisterRequest {
     confirmPassword: string;
 }

--- a/client/src/types/Auth.ts
+++ b/client/src/types/Auth.ts
@@ -44,6 +44,7 @@ export interface ILoginFormValues {
 export interface ILoginRequest {
     email: string;
     password: string;
+    rememberMe: boolean;
 }
 
 export interface ILoginResponse {

--- a/client/src/types/Auth.ts
+++ b/client/src/types/Auth.ts
@@ -25,15 +25,14 @@ export interface IAuthResponse {
     fullName: string;
     email: string;
     role: UserRole;
-    tokens: {
-        accessToken: string;
-        refreshToken: string;
-    };
+    token: string;
+    refreshToken?: string | null;
 }
 
 export interface IApiError {
     errorCode: string;
     message: string;
+    fieldErrors?: Record<string, string>;
 }
 
 export interface ILoginFormValues {


### PR DESCRIPTION
## 📝 Опис

Виправлено два bugs у Login flow:

1. DEV-319:
- Додано специфічну обробку помилки `TOO_MANY_ATTEMPTS` / HTTP 429.
- При 5 невдалих спробах входу UI тепер показує повідомлення з backend response:
  `"Too many failed login attempts. Try again later."`
- Кнопка `Log In` блокується на 5 хвилин після отримання rate limit error.
- Дефолтна помилка `"Server error. Please try again later."` більше не показується для 429.

2. DEV-323:
- Додано поле `rememberMe` у `ILoginRequest`.
- `LoginForm.vue` передає поточне значення checkbox `Remember me` у login request.
- `authService.login()` додає `rememberMe` у payload для `POST /api/v1/auth/login`.
- Це дозволяє backend коректно видавати refreshToken при активному `Remember me`.

Основні змінені файли:
- `client/src/components/forms/LoginForm.vue`
- `client/src/services/authService.ts`
- `client/src/types/Auth.ts`

## 🏷️ Тип зміни

- [x] Bug fix (виправлення помилки)
- [ ] Feature (нова функціональність)
- [x] Refactoring (переробка коду)
- [ ] Documentation (документація)
- [x] UI/UX (оформлення)
- [ ] Performance (оптимізація)
- [ ] Tests (тестування)

## Task Link

- Task: [DEV-319](https://tournamentsystem.atlassian.net/browse/DEV-319?atlOrigin=eyJpIjoiM2U0MGE2NTI3MjYwNDIxN2IwYWQ0OThiNWExZjk2MTIiLCJwIjoiaiJ9)
- Task: [DEV-323](https://tournamentsystem.atlassian.net/browse/DEV-323?atlOrigin=eyJpIjoiNTdmM2I3OGFhNzQ3NGZiZTk4MmM1NzI2YjdmZTA3MTAiLCJwIjoiaiJ9)

## Self-Review Checklist

### Code Quality
- [x] Код відповідає встановленому Code Style Guide
- [x] Немає дублювання коду
- [x] Складні логіки мають зрозумілу структуру
- [x] Назви змінних/функцій зрозумілі та за конвенціями

### Linting & Formatting
- [ ] Лінтер пройдений без помилок (`npm run lint`)
- [x] Немає закоментованого коду
- [x] Немає зайвих `console.log()`
- [x] Формування за конвенціями проекту

### Testing
- [ ] Unit-тести написані та проходять
- [ ] Integration-тести написані та проходять
- [ ] Test coverage >= 80%
- [x] Тести локально пройдені вручну

Перевірено вручну:
- `npm run build` проходить успішно
- при активному checkbox `Remember me` у payload login request передається `rememberMe: true`
- при неактивному checkbox передається `rememberMe: false`
- при HTTP 429 / `TOO_MANY_ATTEMPTS` показується повідомлення від backend
- при HTTP 429 кнопка `Log In` стає disabled
- 401 invalid credentials продовжує показувати `"Invalid email or password"`
- введені дані у формі логіну не очищуються після помилки

### Database (якщо потрібно)
- [ ] Міграції написані та протестовані
- [ ] Rollback працює
- [ ] Індекси додані

Не потрібно для цієї frontend bugfix task.

### Documentation
- [ ] README оновлений
- [ ] API документація оновлена
- [x] Коментарі/структура коду достатні для розуміння
- [ ] Нові ендпоінти задокументовані

API endpoints не змінювались. Frontend адаптовано під актуальний backend login contract.

### Security
- [x] Немає hardcoded secrets/passwords
- [x] Пароль не зберігається у localStorage
- [x] `rememberMe` передається лише як boolean flag
- [x] Authorization/login flow не зберігає чутливі дані поза auth state

### Performance
- [x] Немає зайвих API calls
- [x] Немає важких операцій на клієнті
- [x] Rate limit error не провокує додаткові повторні запити

## Скріншоти (якщо актуально)

Можна додати screenshot з UI після 429:
- повідомлення `"Too many failed login attempts. Try again later."`
- disabled button `Log In`

Також можна додати screenshot з Network payload:
- `rememberMe: true`

## Breaking Changes

- [x] Немає breaking changes
- [ ] Є breaking changes

## Deployment Notes

- [ ] Потребує migrate БД
- [ ] Потребує оновлення environment variables
- [x] Потребує перезавантаження frontend сервісу
- [ ] Потребує очищення кеша

Примітка:
PR створено від гілки `DEV-195-client-side-validation-error-handling`, оскільки зміни стосуються LoginForm та залежать від попередньої validation/error-handling task.

## Reviewer Checklist

- [ ] Код логічний та читаємий
- [ ] Changes відповідають описанню
- [ ] 429 обробляється окремо від 500
- [ ] `rememberMe` присутній у login request payload
- [ ] UI не дозволяє повторно натискати `Log In` під час блокування
- [ ] Немає очевидних багів

[DEV-319]: https://tournamentsystem.atlassian.net/browse/DEV-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ