### PR TITLE
[frontend][DEV-327] Fix registration email conflict validation state

### DIFF
--- a/client/src/components/forms/RegisterForm.vue
+++ b/client/src/components/forms/RegisterForm.vue
@@ -858,6 +858,12 @@ const handleSubmit = async () => {
   box-shadow: none;
 }
 
+.register-form__input-wrapper--error .register-form__input,
+.register-form__input-wrapper--error .register-form__input:focus,
+.register-form__input-wrapper--error .register-form__input:active {
+  border-color: #ff6b6b;
+}
+
 .register-form__input[type='password']::-ms-reveal,
 .register-form__input[type='password']::-ms-clear {
   display: none;

--- a/client/src/components/forms/RegisterForm.vue
+++ b/client/src/components/forms/RegisterForm.vue
@@ -33,6 +33,7 @@
 
           <input
             id="fullName"
+            ref="fullNameInput"
             v-model.trim="form.fullName"
             type="text"
             class="register-form__input"
@@ -65,6 +66,7 @@
 
           <input
             id="phoneNumber"
+            ref="phoneNumberInput"
             :value="form.phoneNumber"
             type="tel"
             class="register-form__input"
@@ -103,6 +105,7 @@
 
           <input
             id="email"
+            ref="emailInput"
             v-model.trim="form.email"
             type="email"
             class="register-form__input"
@@ -157,6 +160,7 @@
 
           <input
             id="dateOfBirth"
+            ref="dateOfBirthInput"
             v-model="form.dateOfBirth"
             type="date"
             class="register-form__input register-form__input--date"
@@ -299,6 +303,7 @@
 
           <input
             id="password"
+            ref="passwordInput"
             v-model="form.password"
             :type="showPassword ? 'text' : 'password'"
             class="register-form__input register-form__input--password"
@@ -378,6 +383,7 @@
 
           <input
             id="confirmPassword"
+            ref="confirmPasswordInput"
             v-model="form.confirmPassword"
             :type="showConfirmPassword ? 'text' : 'password'"
             class="register-form__input register-form__input--password"
@@ -493,6 +499,15 @@ const isSubmitting = ref(false);
 const submitError = ref('');
 const submitSuccess = ref(false);
 
+const fullNameInput = ref<HTMLInputElement | null>(null);
+const phoneNumberInput = ref<HTMLInputElement | null>(null);
+const emailInput = ref<HTMLInputElement | null>(null);
+const dateOfBirthInput = ref<HTMLInputElement | null>(null);
+const passwordInput = ref<HTMLInputElement | null>(null);
+const confirmPasswordInput = ref<HTMLInputElement | null>(null);
+
+const serverRejectedEmail = ref('');
+
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 
@@ -503,6 +518,25 @@ const phoneRegex = /^\+380\s\d{2}\s\d{3}\s\d{2}\s\d{2}$/;
 const backendPhoneRegex = /^\+380\d{9}$/;
 
 const normalizePhoneNumber = (value: string) => value.replace(/\s+/g, '');
+const focusFirstError = () => {
+  const target =
+    errors.fullName
+      ? fullNameInput.value
+      : errors.phoneNumber
+        ? phoneNumberInput.value
+        : errors.email
+          ? emailInput.value
+          : errors.dateOfBirth
+            ? dateOfBirthInput.value
+            : errors.password
+              ? passwordInput.value
+              : errors.confirmPassword
+                ? confirmPasswordInput.value
+                : null;
+
+  target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  target?.focus();
+};
 
 const formatPhone = (digits: string) => {
   let formatted = '+380';
@@ -673,13 +707,29 @@ const validateForm = async () => {
 };
 
 const handleEmailInput = () => {
+  const currentEmail = form.email.trim().toLowerCase();
+  const rejectedEmail = serverRejectedEmail.value.toLowerCase();
+
+  submitError.value = '';
+
+  if (currentEmail === rejectedEmail) {
+    emailIsUnique.value = false;
+    errors.email = 'Email is already in use';
+    return;
+  }
+
   emailIsUnique.value = null;
   errors.email = '';
-  submitError.value = '';
 };
 
 const handleEmailBlur = async () => {
   validateField('email');
+
+  if (form.email.trim().toLowerCase() === serverRejectedEmail.value.toLowerCase()) {
+    emailIsUnique.value = false;
+    errors.email = 'Email is already in use';
+    return;
+  }
 
   if (errors.email || !form.email.trim()) {
     emailIsUnique.value = null;
@@ -715,7 +765,11 @@ const handleSubmit = async () => {
   submitSuccess.value = false;
 
   const isValid = await validateForm();
-  if (!isValid) return;
+
+  if (!isValid) {
+    focusFirstError();
+    return;
+  }
 
   isSubmitting.value = true;
 
@@ -743,10 +797,14 @@ const handleSubmit = async () => {
     if (apiError.errorCode === 'EMAIL_TAKEN') {
       const message = apiError.message || 'Email is already in use';
 
+      serverRejectedEmail.value = form.email.trim();
       emailIsUnique.value = false;
       errors.email = message;
       submitError.value = '';
-    } else if (apiError.fieldErrors) {
+
+      focusFirstError();
+    }
+    else if (apiError.fieldErrors) {
       Object.entries(apiError.fieldErrors).forEach(([field, message]) => {
         const fieldName = field as keyof IRegisterFormValues;
         errors[fieldName] = message;

--- a/client/src/components/forms/RegisterForm.vue
+++ b/client/src/components/forms/RegisterForm.vue
@@ -10,7 +10,10 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="fullName">Name &amp; Surname</label>
-        <div class="register-form__input-wrapper">
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.email }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path
@@ -93,6 +96,7 @@
             type="email"
             class="register-form__input"
             placeholder="example@email.com"
+            @input="handleEmailInput"
             @blur="handleEmailBlur"
           />
         </div>
@@ -102,7 +106,7 @@
           <p v-else-if="emailIsUnique === true" class="register-form__success-text">
             Email is available
           </p>
-          <p v-else-if="emailIsUnique === false" class="register-form__error">
+          <p v-else-if="emailIsUnique === false && !errors.email" class="register-form__error">
             Email is already registered
           </p>
           <p v-else class="register-form__hint"></p>
@@ -657,6 +661,12 @@ const validateForm = async () => {
   return !Object.values(errors).some((value) => value);
 };
 
+const handleEmailInput = () => {
+  emailIsUnique.value = null;
+  errors.email = '';
+  submitError.value = '';
+};
+
 const handleEmailBlur = async () => {
   validateField('email');
 
@@ -722,8 +732,11 @@ const handleSubmit = async () => {
 
 
     if (apiError.errorCode === 'EMAIL_TAKEN') {
-      submitError.value = 'Email is already registered';
-      errors.email = 'Email is already registered';
+      const message = apiError.message || 'Email is already in use';
+
+      emailIsUnique.value = false;
+      errors.email = message;
+      submitError.value = '';
     } else if (apiError.errorCode === 'VALIDATION_ERROR') {
       submitError.value = apiError.message ?? 'Validation error';
     } else {
@@ -797,6 +810,10 @@ const handleSubmit = async () => {
 
 .register-form__input-wrapper--date {
   position: relative;
+}
+
+.register-form__input-wrapper--error .register-form__input {
+  border-color: #ff6b6b;
 }
 
 .register-form__icon {

--- a/client/src/components/forms/RegisterForm.vue
+++ b/client/src/components/forms/RegisterForm.vue
@@ -10,9 +10,10 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="fullName">Name &amp; Surname</label>
+
         <div
           class="register-form__input-wrapper"
-          :class="{ 'register-form__input-wrapper--error': errors.email }"
+          :class="{ 'register-form__input-wrapper--error': errors.fullName }"
         >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
@@ -40,12 +41,17 @@
             @blur="validateField('fullName')"
           />
         </div>
+
         <p class="register-form__error">{{ errors.fullName || '' }}</p>
       </div>
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="phoneNumber">Phone</label>
-        <div class="register-form__input-wrapper">
+
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.phoneNumber }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path
@@ -60,19 +66,24 @@
           <input
             id="phoneNumber"
             :value="form.phoneNumber"
-            @input="handlePhoneInput"
             type="tel"
             class="register-form__input"
             placeholder="+380 XX XXX XX XX"
+            @input="handlePhoneInput"
             @blur="validateField('phoneNumber')"
           />
-          </div>
+        </div>
+
         <p class="register-form__error">{{ errors.phoneNumber || '' }}</p>
       </div>
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="email">Email</label>
-        <div class="register-form__input-wrapper">
+
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.email }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path
@@ -117,7 +128,11 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="dateOfBirth">Date of birth</label>
-        <div class="register-form__input-wrapper register-form__input-wrapper--date">
+
+        <div
+          class="register-form__input-wrapper register-form__input-wrapper--date"
+          :class="{ 'register-form__input-wrapper--error': errors.dateOfBirth }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <path d="M7 2V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
@@ -170,6 +185,7 @@
             </svg>
           </span>
         </div>
+
         <p class="register-form__error">{{ errors.dateOfBirth || '' }}</p>
       </div>
 
@@ -257,7 +273,11 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="password">Password</label>
-        <div class="register-form__input-wrapper">
+
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.password }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <rect
@@ -332,7 +352,11 @@
 
       <div class="register-form__field-group">
         <label class="register-form__label" for="confirmPassword">Confirm Password</label>
-        <div class="register-form__input-wrapper">
+
+        <div
+          class="register-form__input-wrapper"
+          :class="{ 'register-form__input-wrapper--error': errors.confirmPassword }"
+        >
           <span class="register-form__icon">
             <svg viewBox="0 0 24 24" fill="none">
               <rect
@@ -391,6 +415,7 @@
             </svg>
           </button>
         </div>
+
         <p class="register-form__error">{{ errors.confirmPassword || '' }}</p>
       </div>
 
@@ -421,6 +446,7 @@
             />
           </svg>
         </div>
+
         <div>
           <p class="register-form__privacy-title">Your data is protected</p>
           <p class="register-form__privacy-text">
@@ -442,9 +468,7 @@ import { computed, reactive, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { authService } from '../../services/authService';
 import { useAuthStore } from '../../stores/authStore';
-
 import type { IApiError, IRegisterFormValues, IRegisterRequest } from '../../types/Auth';
-
 
 type FormErrors = Partial<Record<keyof IRegisterFormValues, string>>;
 
@@ -472,22 +496,21 @@ const submitSuccess = ref(false);
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 
+const fullNameRegex =
+  /^[A-Za-zА-Яа-яІіЇїЄєҐґ'’-]+(?:\s+[A-Za-zА-Яа-яІіЇїЄєҐґ'’-]+){1,2}$/u;
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const phoneRegex = /^\+380\s\d{2}\s\d{3}\s\d{2}\s\d{2}$/;
+const backendPhoneRegex = /^\+380\d{9}$/;
+
+const normalizePhoneNumber = (value: string) => value.replace(/\s+/g, '');
 
 const formatPhone = (digits: string) => {
   let formatted = '+380';
 
-  if (digits.length > 0) {
-    formatted += ' ' + digits.substring(0, 2);
-  }
-  if (digits.length >= 3) {
-    formatted += ' ' + digits.substring(2, 5);
-  }
-  if (digits.length >= 6) {
-    formatted += ' ' + digits.substring(5, 7);
-  }
-  if (digits.length >= 8) {
-    formatted += ' ' + digits.substring(7, 9);
-  }
+  if (digits.length > 0) formatted += ' ' + digits.substring(0, 2);
+  if (digits.length >= 3) formatted += ' ' + digits.substring(2, 5);
+  if (digits.length >= 6) formatted += ' ' + digits.substring(5, 7);
+  if (digits.length >= 8) formatted += ' ' + digits.substring(7, 9);
 
   return formatted;
 };
@@ -501,21 +524,11 @@ const handlePhoneInput = (event: Event) => {
     digits = '380' + digits;
   }
 
-  digits = digits.substring(3);
-
-  digits = digits.substring(0, 9);
-
+  digits = digits.substring(3, 12);
   form.phoneNumber = formatPhone(digits);
+
+  validateField('phoneNumber');
 };
-
-
-const fullNameRegex =
-  /^[A-Za-zА-Яа-яІіЇїЄєҐґ'’-]+(?:\s+[A-Za-zА-Яа-яІіЇїЄєҐґ'’-]+){1,2}$/u;
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const phoneRegex = /^\+380\s\d{2}\s\d{3}\s\d{2}\s\d{2}$/;
-const backendPhoneRegex = /^\+380\d{9}$/;
-
-const normalizePhoneNumber = (value: string) => value.replace(/\s+/g, '');
 
 const passwordStrengthScore = computed(() => {
   let score = 0;
@@ -540,9 +553,11 @@ const strengthClass = computed(() => {
   if (!form.password || passwordStrengthScore.value <= 2) {
     return 'register-form__strength-fill--weak';
   }
+
   if (passwordStrengthScore.value === 3) {
     return 'register-form__strength-fill--medium';
   }
+
   return 'register-form__strength-fill--strong';
 });
 
@@ -607,11 +622,7 @@ const validateField = (field: keyof IRegisterFormValues) => {
       break;
 
     case 'role':
-      if (!form.role) {
-        errors.role = 'Role is required';
-      } else {
-        errors.role = '';
-      }
+      errors.role = form.role ? '' : 'Role is required';
       break;
 
     case 'password':
@@ -658,7 +669,7 @@ const validateForm = async () => {
     }
   }
 
-  return !Object.values(errors).some((value) => value);
+  return !Object.values(errors).some(Boolean);
 };
 
 const handleEmailInput = () => {
@@ -676,6 +687,7 @@ const handleEmailBlur = async () => {
   }
 
   isCheckingEmail.value = true;
+
   try {
     const isUnique = await authService.checkEmailUnique(form.email.trim());
     emailIsUnique.value = isUnique;
@@ -719,7 +731,6 @@ const handleSubmit = async () => {
 
     const response = await authService.register(payload);
 
-
     authStore.setAuth(response);
     submitSuccess.value = true;
 
@@ -727,15 +738,20 @@ const handleSubmit = async () => {
       router.push(authStore.getDashboardRouteByRole(response.role));
     }, 900);
   } catch (error: unknown) {
-
     const apiError = error as IApiError;
-
 
     if (apiError.errorCode === 'EMAIL_TAKEN') {
       const message = apiError.message || 'Email is already in use';
 
       emailIsUnique.value = false;
       errors.email = message;
+      submitError.value = '';
+    } else if (apiError.fieldErrors) {
+      Object.entries(apiError.fieldErrors).forEach(([field, message]) => {
+        const fieldName = field as keyof IRegisterFormValues;
+        errors[fieldName] = message;
+      });
+
       submitError.value = '';
     } else if (apiError.errorCode === 'VALIDATION_ERROR') {
       submitError.value = apiError.message ?? 'Validation error';
@@ -747,6 +763,7 @@ const handleSubmit = async () => {
   }
 };
 </script>
+
 
 <style scoped>
 .register-form {
@@ -810,10 +827,6 @@ const handleSubmit = async () => {
 
 .register-form__input-wrapper--date {
   position: relative;
-}
-
-.register-form__input-wrapper--error .register-form__input {
-  border-color: #ff6b6b;
 }
 
 .register-form__icon {
@@ -882,6 +895,13 @@ const handleSubmit = async () => {
   -webkit-box-shadow: 0 0 0 1000px rgba(21, 49, 206, 0.47) inset;
   transition: background-color 9999s ease-in-out 0s;
   border: 1px solid #1531ce;
+}
+
+.register-form__input-wrapper--error .register-form__input:-webkit-autofill,
+.register-form__input-wrapper--error .register-form__input:-webkit-autofill:hover,
+.register-form__input-wrapper--error .register-form__input:-webkit-autofill:focus,
+.register-form__input-wrapper--error .register-form__input:-webkit-autofill:active {
+  border-color: #ff6b6b;
 }
 
 .register-form__input::placeholder {
@@ -1070,7 +1090,9 @@ const handleSubmit = async () => {
   height: 100%;
   width: 35%;
   border-radius: 999px;
-  transition: width 0.2s ease, background 0.2s ease;
+  transition:
+    width 0.2s ease,
+    background 0.2s ease;
 }
 
 .register-form__strength-fill--weak {
@@ -1105,7 +1127,10 @@ const handleSubmit = async () => {
   font-size: 16px;
   font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .register-form__submit:hover {
@@ -1227,3 +1252,4 @@ const handleSubmit = async () => {
   }
 }
 </style>
+

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -11,6 +11,8 @@ import type {
 } from '../types/Auth';
 
 type BackendErrorResponse = {
+    errorCode?: string;
+    message?: string;
     error?: {
         code?: number;
         type?: string;
@@ -44,7 +46,7 @@ const buildApiError = (
     data: BackendErrorResponse | undefined,
     fallbackMessage: string,
 ): IApiError => {
-    let errorCode = 'INTERNAL_ERROR';
+    let errorCode = data?.errorCode ?? 'INTERNAL_ERROR';
 
     if (status === 400) {
         errorCode = 'VALIDATION_ERROR';
@@ -72,7 +74,7 @@ const buildApiError = (
 
     return {
         errorCode,
-        message: data?.error?.message ?? fallbackMessage,
+        message: data?.message ?? data?.error?.message ?? fallbackMessage,
         fieldErrors: Object.keys(fieldErrors).length ? fieldErrors : undefined,
     };
 };


### PR DESCRIPTION
## 📝 Опис

Виправлено DEV-327: конфліктні стани валідації та дублювання помилок при server-side відповіді на сторінці реєстрації.

Основні зміни:
- Виправлено обробку `EMAIL_TAKEN` / HTTP 409 у `RegisterForm.vue`
- Зелене повідомлення `Email is available` тепер очищується після server-side помилки
- Server-side помилка email відображається тільки локально під полем Email
- Глобальний червоний alert більше не дублює помилку `EMAIL_TAKEN`
- Поле Email підсвічується червоною рамкою при помилці
- UI використовує повідомлення з backend response `apiError.message`, наприклад:
  - `Email is already in use`
- При редагуванні email очищується попередній server-side стан помилки

## 🏷️ Тип зміни

- [x] Bug fix (виправлення помилки)
- [ ] Feature (нова функціональність)
- [ ] Refactoring (переробка коду)
- [ ] Documentation (документація)
- [x] UI/UX (оформлення)
- [ ] Performance (оптимізація)
- [ ] Tests (тестування)

## Task Link

- Task: [DEV-327](https://tournamentsystem.atlassian.net/browse/DEV-327?atlOrigin=eyJpIjoiZGZlNDJiZmIyY2NlNDMwMTliOGJiNWFiZTJhMzM4ZmEiLCJwIjoiaiJ9)

## Self-Review Checklist

### Code Quality
- [x] Код відповідає встановленому Code Style Guide
- [x] Немає дублювання коду
- [x] Логіка обробки `EMAIL_TAKEN` локалізована в одному місці
- [x] Назви змінних/функцій зрозумілі та за конвенціями

### Linting & Formatting
- [ ] Лінтер пройдений без помилок (`npm run lint`)
- [x] Немає закоментованого коду
- [x] Немає зайвих `console.log()`
- [x] Формування за конвенціями проекту

### Testing
- [ ] Unit-тести написані та проходять
- [ ] Integration-тести написані та проходять
- [ ] Test coverage >= 80%
- [x] Тести локально пройдені вручну

Перевірено вручну:
- `npm run build` проходить успішно
- при HTTP 409 / `EMAIL_TAKEN` зелений текст `Email is available` зникає
- повідомлення з backend response показується під полем Email
- глобальний alert не дублює помилку email
- поле Email підсвічується червоною рамкою
- при редагуванні email попередній server-side error state очищується
- інші помилки реєстрації продовжують показуватись через існуючу логіку

### Database (якщо потрібно)
- [ ] Міграції написані та протестовані
- [ ] Rollback працює
- [ ] Індекси додані

Не потрібно для цієї frontend bugfix task.

### Documentation
- [ ] README оновлений
- [ ] API документація оновлена
- [x] Поведінка UI узгоджена з Acceptance Criteria UC-04
- [ ] Нові ендпоінти задокументовані

API endpoints не змінювались.

### Security
- [x] Немає hardcoded secrets/passwords
- [x] Server-side помилки не логуються як sensitive data
- [x] Валідація email не зберігає зайві дані

### Performance
- [x] Немає зайвих API calls
- [x] Немає важких операцій на клієнті
- [x] Очищення validation state виконується локально

## Скріншоти

<img width="643" height="430" alt="image" src="https://github.com/user-attachments/assets/4c5c606a-6982-4916-9597-e051550c3dbc" />

<img width="1118" height="729" alt="image" src="https://github.com/user-attachments/assets/fc9dc665-d677-40a3-b62b-d5b2fcca5454" />
## Breaking Changes

- [x] Немає breaking changes
- [ ] Є breaking changes

## Deployment Notes

- [ ] Потребує migrate БД
- [ ] Потребує оновлення environment variables
- [x] Потребує перезавантаження frontend сервісу
- [ ] Потребує очищення кеша

Примітка:
PR створено від гілки `DEV-169-participants-count-validation`, оскільки DEV-327 накладається поверх актуального frontend validation flow.

## Reviewer Checklist

- [ ] Код логічний та читаємий
- [ ] Changes відповідають описанню
- [ ] `EMAIL_TAKEN` показується тільки під Email
- [ ] Зелений success state очищується після server-side помилки
- [ ] Email input має червону рамку при помилці
- [ ] Використовується message з backend response
- [ ] Немає очевидних багів

[DEV-327]: https://tournamentsystem.atlassian.net/browse/DEV-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ