### PR TITLE
DEV-328 fix: use server message for EMAIL_TAKEN instead of hardcoded …

### DIFF
--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -11,6 +11,8 @@ import type {
 } from '../types/Auth';
 
 type BackendErrorResponse = {
+    errorCode?: string;
+    message?: string;
     error?: {
         code?: number;
         type?: string;
@@ -44,7 +46,7 @@ const buildApiError = (
     data: BackendErrorResponse | undefined,
     fallbackMessage: string,
 ): IApiError => {
-    let errorCode = 'INTERNAL_ERROR';
+    let errorCode = data?.errorCode ?? 'INTERNAL_ERROR';
 
     if (status === 400) {
         errorCode = 'VALIDATION_ERROR';
@@ -72,7 +74,7 @@ const buildApiError = (
 
     return {
         errorCode,
-        message: data?.error?.message ?? fallbackMessage,
+        message: data?.message ?? data?.error?.message ?? fallbackMessage,
         fieldErrors: Object.keys(fieldErrors).length ? fieldErrors : undefined,
     };
 };


### PR DESCRIPTION
## 🧾 Опис задачі
Виправлено проблему, при якій фронтенд ігнорував текст помилки з відповіді сервера (`response.message`) та відображав захардкоджений текст.

---

## ❗ Проблема
При отриманні помилки 409 Conflict (EMAIL_TAKEN):

- UI відображав: "Email is already registered"
- Backend повертав: "Email is already in use"

Це створювало розбіжність між frontend і backend та порушувало вимоги TC-T-04.9.

---

## ✅ Що зроблено

- Видалено захардкоджений текст помилки для EMAIL_TAKEN
- Реалізовано використання `apiError.message` з відповіді сервера
- Забезпечено відображення актуального тексту помилки під полем Email
- Збережено правильну логіку валідації (без дублювання помилок)
- Синхронізовано UI з backend response

---

## 🧪 Тестування

Перевірено вручну:

1. Відкрити сторінку `/register`
2. Ввести існуючий email
3. Заповнити форму
4. Натиснути "Sign Up"
5. Отримати відповідь 409

### Очікуваний результат:
- Відображається текст помилки з backend (`Email is already in use`)
- Помилка показується лише під полем Email
- Поле Email підсвічується червоним

### Фактичний результат:
- Повністю відповідає очікуваному

---

## 🔗 Jira Task
[DEV-328](https://tournamentsystem.atlassian.net/browse/DEV-328?atlOrigin=eyJpIjoiYzQxNmE3ZGY3YTNmNDU1MmI4NDZlYTdlMGY4OWU3MzYiLCJwIjoiaiJ9)


## 🚀 Результат
Фронтенд коректно відображає текст помилки з сервера та відповідає технічним вимогам TC-T-04.9.

[DEV-328]: https://tournamentsystem.atlassian.net/browse/DEV-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ