### PR TITLE
feat(ui): DEV-241 — toast notification after joining tournament via l…

### DIFF
--- a/client/src/components/tournament/TournamentHeader.vue
+++ b/client/src/components/tournament/TournamentHeader.vue
@@ -19,6 +19,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   'refresh-bracket': []
   'refresh-participants': []
+  'show-toast': [message: string]
 }>()
 
 const router = useRouter()
@@ -83,6 +84,7 @@ const handleJoin = async () => {
       authStore.currentUser!.userId,
     )
     emit('refresh-participants')
+    emit('show-toast', `You have successfully joined the ${props.tournament.title}!`)
   } catch (e: any) {
     if (e?.response?.status === 409) {
       actionError.value = 'You are already registered or the tournament is full.'

--- a/client/src/views/JoinTournamentPage.vue
+++ b/client/src/views/JoinTournamentPage.vue
@@ -19,6 +19,7 @@ onMounted(async () => {
 
   try {
     await participationService.addParticipant(id, authStore.currentUser!.userId)
+    sessionStorage.setItem('joinToast', `You have successfully joined the tournament!`)
   } catch (e: any) {
     // 409 — вже зареєстрований, просто йдемо на деталі
     console.warn('Join error (may already be registered):', e)

--- a/client/src/views/ViewTournament.vue
+++ b/client/src/views/ViewTournament.vue
@@ -33,6 +33,11 @@ const loading = ref(true)
 const error = ref(false)
 const activeTab = ref('overview')
 
+const showToast = (msg: string) => {
+  toast.value = msg
+  setTimeout(() => { toast.value = '' }, 4000)
+}
+
 onMounted(async () => {
   try {
     loading.value = true
@@ -45,6 +50,12 @@ onMounted(async () => {
     tournament.value = tournamentData
     participants.value = participantsData
     bracket.value = bracketData
+    const joinToast = sessionStorage.getItem('joinToast')
+    if (joinToast) {
+      toast.value = joinToast
+      sessionStorage.removeItem('joinToast')
+      setTimeout(() => { toast.value = '' }, 4000)
+    }
   } catch (e) {
     console.error(e)
     error.value = true
@@ -98,6 +109,7 @@ const handleRefreshParticipants = async () => {
             : null"
           @refresh-bracket="handleBracketGenerated"
           @refresh-participants="handleRefreshParticipants"
+          @show-toast="showToast"
         />
 
         <TournamentTabs


### PR DESCRIPTION
## 📝 Опис

Додано toast-повідомлення після успішного приєднання до турніру через посилання та через кнопку "Submit an application".

Основні зміни:
- `JoinTournamentPage.vue` — після успішного `addParticipant` записує повідомлення в `sessionStorage`
- `ViewTournament.vue` — зчитує `sessionStorage` після редіректу і показує toast, додано `showToast` хелпер
- `TournamentHeader.vue` — після успішного `handleJoin` емітує `show-toast` з назвою турніру

## 🏷️ Тип зміни

- [ ] Bug fix (виправлення помилки)
- [x] Feature (нова функціональність)
- [ ] Refactoring (переробка коду)
- [ ] Documentation (документація)
- [x] UI/UX (оформлення)
- [ ] Performance (оптимізація)
- [ ] Tests (тестування)

## Task Link

- Task: [[DEV-241](https://tournamentsystem.atlassian.net/browse/DEV-241)](https://tournamentsystem.atlassian.net/browse/DEV-241)

## Self-Review Checklist

### Code Quality
- [x] Код відповідає встановленому [[Code Style Guide](https://claude.ai/docs/NAMING_CONVENTIONS.md)](../docs/NAMING_CONVENTIONS.md)
- [x] Немає дублювання коду
- [x] Назви змінних/функцій зрозумілі та за конвенціями

### Linting & Formatting
- [x] Лінтер пройдений без помилок (`npm run lint`)
- [x] Немає закоментованого коду
- [x] Немає `console.log()`
- [x] Формування за конвенціями проекту

### Testing
- [ ] Unit-тести написані та проходять
- [ ] Integration-тести написані та проходять
- [ ] Test coverage >= 80%
- [ ] Тести локально пройдені

### Database
Не потрібно

### Documentation
- [x] API документація не змінювалась (тільки UI)

### Security
- [x] `sessionStorage` очищається одразу після зчитування
- [x] Toast показується тільки після успішного запиту

### Performance
- [x] Немає зайвих API calls
- [x] `sessionStorage` використовується тільки для передачі одного повідомлення між сторінками

## Скріншоти

### Before (Було)
- Після приєднання через посилання — тихий редірект на сторінку турніру без повідомлення
- Після кліку "Submit an application" — жодного підтвердження успіху

### After (Стало)
- Після приєднання через посилання → toast "Ви успішно приєднались до турніру!" на сторінці турніру
- Після кліку "Submit an application" → toast "Ви успішно приєднались до [назва турніру]!"
- Toast зникає автоматично через 4 секунди

## Breaking Changes
- [x] Немає breaking changes

## Deployment Notes
- [x] Не потребує міграцій
- [x] Не потребує оновлення environment variables

## Reviewer Checklist (для рев'ювера)

- [ ] Код логічний та читаємий
- [ ] Changes відповідають описанню
- [ ] Тести покривають нові зміни
- [ ] Немає очевидних багів
- [ ] Документація актуальна
- [ ] Performance не погіршився

[DEV-241]: https://tournamentsystem.atlassian.net/browse/DEV-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ