### PR TITLE
[fix] DEV-448: [BACK] SaveMatchResult при…

### DIFF
--- a/server/TournamentPlatformSystemWebApi.Infrastructure/Services/TournamentService.cs
+++ b/server/TournamentPlatformSystemWebApi.Infrastructure/Services/TournamentService.cs
@@ -336,7 +336,7 @@ public class TournamentService : ITournamentService
         if (match.IsBye == true)
             throw new ValidationException("Cannot enter a result for a bye match");
 
-        if (!match.TeamAId.HasValue || !match.TeamBId.HasValue)
+        if (match.Status == "pending" || !match.TeamAId.HasValue || !match.TeamBId.HasValue || match.TeamAId == Guid.Empty || match.TeamBId == Guid.Empty)
             throw new MatchNotReadyException("Match is not ready for result entry");
 
         if (match.WinnerId != null)


### PR DESCRIPTION
…ймає результат для матчу-заглушки (pending) — у сітку записується WinnerId = Guid.Empty
## 📝 Опис

Expand the readiness check before accepting match results. The guard now also rejects matches with Status == "pending" and treats TeamAId/TeamBId equal to Guid.Empty as not ready, in addition to null IDs. This prevents submitting results for pending or improperly initialized matches (e.g., empty GUIDs) and preserves the existing bye/validation behavior.


## 🏷️ Тип зміни

<!-- Виберіть відповідний тип -->
- [x] Bug fix (виправлення помилки)
- [ ] Feature (нова функціональність)
- [ ] Refactoring (переробка коду)
- [ ] Documentation (документація)
- [ ] UI/UX (оформлення)
- [ ] Performance (оптимізація)
- [ ] Tests (тестування)

##  Task Link

<!-- Посилання на завдання в Jira -->
- Task: [DEV-448](https://tournamentsystem.atlassian.net/browse/DEV-448)

## Self-Review Checklist

### Code Quality
- [x] Код відповідає встановленому [Code Style Guide](../docs/NAMING_CONVENTIONS.md)
- [x] Немає дублювання коду
- [x] Складні логіки мають коментарі
- [x] Назви змінних/функцій зрозумілі та за конвенціями

### Linting & Formatting
- [x] Лінтер пройдений без помилок (`npm run lint` / `dotnet format`)
- [x] Немає закоментованого коду
- [x] Немає `console.log()` / `Debug.WriteLine()` (крім логування)
- [x] Формування за конвенціями проекту



[DEV-448]: https://tournamentsystem.atlassian.net/browse/DEV-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ