### PR TITLE
[fix] DEV-451 [BACK] Race condition при приєднанні до турніру — ліміт…

### DIFF
--- a/server/TournamentPlatformSystemWebApi.Infrastructure/Services/TournamentService.cs
+++ b/server/TournamentPlatformSystemWebApi.Infrastructure/Services/TournamentService.cs
@@ -547,10 +547,6 @@ public class TournamentService : ITournamentService
         // Only allow adding participants while registration is open
         if (existing.Status != TournamentPlatformSystemWebApi.Core.Entities.TournamentStatus.REGISTRATION_OPEN)
             throw new TournamentPlatformSystemWebApi.Common.Exceptions.TournamentClosedForChangesException("Registration for tournament is already finished");
-        // check max participants
-        var participantsCount = await _tournamentRepository.GetParticipantsCountAsync(tournamentId);
-        if (existing.MaxTeams > 0 && participantsCount >= existing.MaxTeams)
-            throw new TournamentPlatformSystemWebApi.Common.Exceptions.MaxParticipantsReachedException("Maximum amount of participants is achieved, there is no spot for you");
 
         // check user exists
         var user = await _userRepository.GetUserWithDetails(userId);
@@ -561,10 +557,6 @@ public class TournamentService : ITournamentService
             throw new UnauthorizedAccessException("Only the tournament organizer can add other participants");
         // user must be a player (not organizer)
         if (user.IsOrganizer == true) throw new UnauthorizedAccessException("User does not have player role");
-
-        // check already added
-        var already = await _tournamentRepository.IsUserInTournamentAsync(tournamentId, userId);
-        if (already) throw new TournamentPlatformSystemWebApi.Common.Exceptions.ParticipantAlreadyAddedException("You already joined to this tournament");
 
         // derive team name from user details
         var displayName = user.FullName?.Trim();
@@ -592,18 +584,81 @@ public class TournamentService : ITournamentService
             teamName = $"player_{userId.ToString().Substring(0, 8)}";
         }
 
-        var team = await _tournamentRepository.AddParticipantAsync(tournamentId, userId, teamName);
+        var provider = _context.Database.ProviderName ?? string.Empty;
+        var useTransaction = _context.Database.CurrentTransaction == null && !provider.Contains("InMemory", StringComparison.OrdinalIgnoreCase);
+        await using var txn = useTransaction ? await _context.Database.BeginTransactionAsync() : null;
 
-        return new TournamentPlatformSystemWebApi.Application.DTOs.TeamDto
+        try
         {
-            Id = team.Id,
-            Name = team.Name,
-            UserId = userId,
-            TournamentId = team.TournamentId,
-            IsDisqualified = team.IsDisqualified,
-            CreatedAt = team.CreatedAt,
-            UpdatedAt = team.UpdatedAt
-        };
+            var tournamentLock = await _context.Set<TournamentModel>()
+                .FromSqlInterpolated($"SELECT * FROM tournament WHERE id = {tournamentId} FOR UPDATE")
+                .FirstOrDefaultAsync();
+
+            if (tournamentLock == null)
+                throw new KeyNotFoundException("Tournament not found");
+
+            if (tournamentLock.Status == TournamentStatusType.REGISTRATION_OPEN
+                && tournamentLock.RegistrationDeadline != default
+                && tournamentLock.RegistrationDeadline <= DateTime.UtcNow)
+            {
+                tournamentLock.Status = TournamentStatusType.REGISTRATION_CLOSED;
+                tournamentLock.UpdatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
+                _context.Set<TournamentModel>().Update(tournamentLock);
+                await _context.SaveChangesAsync();
+                throw new TournamentPlatformSystemWebApi.Common.Exceptions.TournamentClosedForChangesException("Registration for tournament is already finished");
+            }
+
+            if (tournamentLock.Status != TournamentStatusType.REGISTRATION_OPEN)
+                throw new TournamentPlatformSystemWebApi.Common.Exceptions.TournamentClosedForChangesException("Registration for tournament is already finished");
+
+            var participantsCount = await _tournamentRepository.GetParticipantsCountAsync(tournamentId);
+            if (existing.MaxTeams > 0 && participantsCount >= existing.MaxTeams)
+                throw new TournamentPlatformSystemWebApi.Common.Exceptions.MaxParticipantsReachedException("Maximum amount of participants is achieved, there is no spot for you");
+
+            var already = await _tournamentRepository.IsUserInTournamentAsync(tournamentId, userId);
+            if (already)
+                throw new TournamentPlatformSystemWebApi.Common.Exceptions.ParticipantAlreadyAddedException("You already joined to this tournament");
+
+            TournamentPlatformSystemWebApi.Core.Entities.Team team;
+            try
+            {
+                team = await _tournamentRepository.AddParticipantAsync(tournamentId, userId, teamName);
+            }
+            catch (DbUpdateException dbEx)
+            {
+                if (dbEx.InnerException?.Message?.Contains("unique_user_tournament", StringComparison.InvariantCultureIgnoreCase) == true)
+                {
+                    throw new TournamentPlatformSystemWebApi.Common.Exceptions.ParticipantAlreadyAddedException("You already joined to this tournament");
+                }
+
+                throw;
+            }
+
+            if (useTransaction && txn != null)
+            {
+                await txn.CommitAsync();
+            }
+
+            return new TournamentPlatformSystemWebApi.Application.DTOs.TeamDto
+            {
+                Id = team.Id,
+                Name = team.Name,
+                UserId = userId,
+                TournamentId = team.TournamentId,
+                IsDisqualified = team.IsDisqualified,
+                CreatedAt = team.CreatedAt,
+                UpdatedAt = team.UpdatedAt
+            };
+        }
+        catch
+        {
+            if (useTransaction && txn != null)
+            {
+                await txn.RollbackAsync();
+            }
+
+            throw;
+        }
     }
 
     public async Task RemoveParticipantAsync(Guid tournamentId, Guid userId)


### PR DESCRIPTION
… maxParticipants можна перевищити, можливий подвійний запис учасника


## 📝 Опис

Wrap participant creation in a DB-level lock and transaction to prevent race conditions. Query the tournament with FOR UPDATE, re-check registration deadline/status and max participants inside the lock, and move the "already joined" check there. Start a transaction only for non-InMemory providers, commit on success and rollback on error. Also catch unique constraint DbUpdateException (unique_user_tournament) and translate it into ParticipantAlreadyAddedException to handle concurrent inserts gracefully.

## 🏷️ Тип зміни

<!-- Виберіть відповідний тип -->
- [x] Bug fix (виправлення помилки)
- [ ] Feature (нова функціональність)
- [ ] Refactoring (переробка коду)
- [ ] Documentation (документація)
- [ ] UI/UX (оформлення)
- [ ] Performance (оптимізація)
- [ ] Tests (тестування)

##  Task Link

<!-- Посилання на завдання в Jira -->
- Task: [DEV-451](https://tournamentsystem.atlassian.net/browse/DEV-451)

## Self-Review Checklist

### Code Quality
- [x] Код відповідає встановленому [Code Style Guide](../docs/NAMING_CONVENTIONS.md)
- [x] Немає дублювання коду
- [x] Складні логіки мають коментарі
- [x] Назви змінних/функцій зрозумілі та за конвенціями

### Linting & Formatting
- [x] Лінтер пройдений без помилок (`npm run lint` / `dotnet format`)
- [x] Немає закоментованого коду
- [x] Немає `console.log()` / `Debug.WriteLine()` (крім логування)
- [x] Формування за конвенціями проекту

[DEV-451]: https://tournamentsystem.atlassian.net/browse/DEV-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ